### PR TITLE
Use a relative path for default rust root.

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -87,7 +87,7 @@ jobs:
           if [ -n "${{ inputs.rust_root }}" ] ; then
             root="${{ inputs.rust_root }}"
           else
-            root="${{ github.workspace }}"
+            root="."
           fi
           echo "rust_root=$root" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Tested in https://github.com/IronCoreLabs/actions-test/pull/226.

Still need to check in a repo where we're setting `rust_root`.