### PR TITLE
Remove concurrency limit from rust-artifact

### DIFF
--- a/.github/workflows/rust-artifact.yaml
+++ b/.github/workflows/rust-artifact.yaml
@@ -4,9 +4,6 @@
 # - all customization should be available via inputs. If anything isn't available, try to add it to this as an input instead of copying and modifying directly
 
 name: Rust Artifact
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
This is causing issues in files that call this while having other jobs in the same workflow file