### PR TITLE
Add reusable Bump Version workflow

### DIFF
--- a/.github/bump-version.bump.sh
+++ b/.github/bump-version.bump.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# This script is copied from the depot repo; edit it there, not in the destination repo.
-
 # Decide what the next versions are going to be. Inputs are the mode, current version, and optional release version override.
 # Outputs are the new release version and the new development version.
 

--- a/.github/bump-version.bump.sh
+++ b/.github/bump-version.bump.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# This script is copied from the depot repo; edit it there, not in the destination repo.
+
+# Decide what the next versions are going to be. Inputs are the mode, current version, and optional release version override.
+# Outputs are the new release version and the new development version.
+
+# Mode can be "release" or "prerelease". See bump-version.yaml for details.
+
+set -e
+
+case "$#" in
+"2")
+    MODE="$1"
+    CURRENTVERS="$2"
+    ;;
+"3")
+    MODE="$1"
+    CURRENTVERS="$2"
+    RELEASEVERS="$3"
+    ;;
+*)
+    echo "Usage: $0 mode current_vers [new_vers]" 1>&2
+    exit 1
+esac
+if [ "${MODE}" != "release" ] && [ "${MODE}" != "prerelease" ] ; then
+    echo "Invalid mode '${MODE}'" 1>&2
+    exit 1
+fi
+
+for V in ${CURRENTVERS} ${RELEASEVERS} ; do
+    # Sanity check: Ignoring any pre-release info, version must not be 0.0.0.
+    if [ "${V/-*/}" = "0.0.0" ] ; then
+        echo "Illegal zero version '${V}'" 1>&2
+        exit 1
+    fi
+    # Sanity check: Must start with a valid semver.
+    if ! [[ ${V} =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))? ]] ; then
+        echo "Invalid version '${V}'" 1>&2
+        exit 1
+    fi
+done
+
+# Derive a new release version.
+if [ -z "${RELEASEVERS}" ] ; then
+    case "${MODE}" in
+    "release")
+        RELEASEVERS="${CURRENTVERS/-*}"
+        ;;
+    "prerelease")
+        # Replace [-.]pre[-.$] with [-.]rc[-.$].
+        RELEASEVERS="$(echo "${CURRENTVERS}" | sed -E 's/([-.])pre([-.]|$)/\1rc\2/')"
+        # If no [-.]rc[-.$], append -rc.0.
+        if ! [[ ${RELEASEVERS} =~ [-.]rc([-.]|$) ]] ; then
+            RELEASEVERS="${RELEASEVERS}-rc.0"
+        fi
+        # If there's no number after the "rc", append ".0".
+        if ! [[ ${RELEASEVERS} =~ [-.]rc[-.][0-9]+ ]] ; then
+            RELEASEVERS="${RELEASEVERS}.0"
+        fi
+        ;;
+    esac
+fi
+# The prefix is there to support Go's release naming conventions.
+echo "release=${BUMP_VERSION_RELEASE_PREFIX}${RELEASEVERS}" >> "$GITHUB_OUTPUT"
+
+# Derive a new bumped version from the release version.
+# Increment the last number in the string.
+VERSION="$(echo "${RELEASEVERS}" | gawk '{ start=match($0, /(.*[^0-9])([0-9]+)([^0-9]*)$/, a) ; a[2] += 1 ; printf("%s%s%s", a[1], a[2], a[3]) }')"
+# Replace [-.]rc[-.$] with pre.
+VERSION="$(echo "${VERSION}" | sed -E 's/([-.])rc([-.]|$)/\1pre\2/')"
+# If no [-.]pre[-.$], then append -pre.
+if ! [[ ${VERSION} =~ [-.]pre([-.]|$) ]] ; then
+    VERSION="${VERSION}-pre"
+fi
+echo "bumped=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/bump-version.get.sh
+++ b/.github/bump-version.get.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# This script is copied from the depot repo; edit it there, not in the destination repo.
+
+# Get the semver from various files in the repo.
+
+# Always performs sanity checking:
+# - There must be at least one version file.
+# - All version files must agree. (Ignoring the contents but not existence of pre-release version.)
+# - The version must be a valid semver.
+# - The version must not be 0.0.0.
+
+set -e
+
+# Parse args
+if [ $# -gt 0 ] ; then
+    echo "Usage: $0" 1>&2
+    exit 1
+fi
+
+# Find the version files in this directory or its descendants, but don't recurse too deep.
+# This line must be kept in sync with "bump-version.set.sh".
+VERSFILES=$(find . -maxdepth 3 ! -path ./.git/\* | grep -v /node_modules/ | grep -E '.*/(version|Cargo.toml|version.go|package.json|pom.xml|version.sbt|build.gradle.kts)$')
+
+# Do we have at least one?
+if [ -z "${VERSFILES}" ] ; then
+    echo "No version files found; aborting" 1>&2
+    exit 1
+fi
+
+# Read the versions.
+CURRENTVERS=""
+for FILE in ${VERSFILES} ; do
+    # Parse each version file according to its type.
+    case $(basename "${FILE}") in
+    version)
+        # It's a file to capture version info for generic things that don't have their own format.
+        VERS=$(cat "${FILE}")
+        ;;
+    Cargo.toml)
+        VERS=$(cargo metadata --manifest-path "${FILE}" --no-deps --offline --format-version 1 | jq -re '.packages[0].version')
+        ;;
+    version.go)
+        VERS=$(grep "const Version" < "${FILE}" | sed -e 's/^[^"]*"//' -e 's/"$//')
+        ;;
+    package.json)
+        if [ "$(dirname "${FILE}")" = "." ] ; then
+            # This is the root package.json, so we want .version.
+            VERS=$(jq -re '.version' < "${FILE}")
+        else
+            # This isn't the root package.json, so we assume it depends on the package declared in the root package.json. We need to
+            # get the root package's name.
+            ROOTJSNAME="$(jq -re '.name' < package.json)"
+            VERS=$(jq -re ".dependencies[\"${ROOTJSNAME}\"]" < "${FILE}")
+            # Strip off any leading "^".
+            VERS=${VERS/^/}
+        fi
+        ;;
+    pom.xml)
+        if [ "$(dirname "${FILE}")" = "." ] ; then
+            # This is the root pom.xml, so we want /m:project/m:version.
+            VERS=$(xmlstarlet sel -N m="http://maven.apache.org/POM/4.0.0" -t -v "/m:project/m:version" < "${FILE}")
+        else
+            # This isn't the root pom.xml, so we assume it depends on the package declared in the root pom.xml. We need to get the
+            # root pom's artifactId.
+            ROOTID=$(xmlstarlet sel -N m="http://maven.apache.org/POM/4.0.0" -t -v "/m:project/m:artifactId" < pom.xml)
+            # Select /m:project/m:dependencies/m:dependency/m:version where it has a sibling m:artifactId with the correct value.
+            XPATH="/m:project/m:dependencies/m:dependency[m:artifactId=\"${ROOTID}\"]/m:version"
+            VERS=$(xmlstarlet sel -N m="http://maven.apache.org/POM/4.0.0" -t -v "${XPATH}" < "${FILE}")
+        fi
+        ;;
+    version.sbt)
+        VERS=$(sed -e 's/^[^"]*"//' -e 's/"$//' < "${FILE}")
+        ;;
+    build.gradle.kts)
+        VERS=$(grep "^version.*=" < "${FILE}" | sed -e 's/^[^"]*"//' -e 's/"$//')
+        ;;
+    *)
+        echo "Can't parse '${FILE}' for version" 1>&2
+        exit 1
+        ;;
+    esac
+
+    if [ -z "${VERS}" ] ; then
+        echo "Empty version from '${FILE}'" 1>&2
+        exit 1
+    fi
+
+    # If this is the first parsed version file, then set current version.
+    if [ -z "${CURRENTVERS}" ] ; then
+        CURRENTVERS="${VERS}"
+    fi
+
+    # Compare this file's version to other files' version. Ignore anything after the "-" in a pre-release version, but keep the "-"
+    # so a release version is unequal to a pre-release.
+    if ! [ "${CURRENTVERS/-*/-}" = "${VERS/-*/-}" ] ; then
+        echo "Version '${VERS}' in '${FILE}' doesn't match '${CURRENTVERS}' from others in '${VERSFILES}'" 1>&2
+        exit 1
+    fi
+done
+
+# Sanity check: Ignoring any pre-release info, version must not be 0.0.0.
+if [ "${CURRENTVERS/-*/}" = "0.0.0" ] ; then
+    echo "Illegal zero version '${CURRENTVERS}'" 1>&2
+    exit 1
+fi
+# Sanity check: Must start with a valid semver.
+if ! [[ ${CURRENTVERS} =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))? ]] ; then
+    echo "Invalid version '${CURRENTVERS}'" 1>&2
+    exit 1
+fi
+
+echo "${CURRENTVERS}"

--- a/.github/bump-version.get.sh
+++ b/.github/bump-version.get.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# This script is copied from the depot repo; edit it there, not in the destination repo.
-
 # Get the semver from various files in the repo.
 
 # Always performs sanity checking:

--- a/.github/bump-version.set.sh
+++ b/.github/bump-version.set.sh
@@ -129,7 +129,7 @@ done
 
 # If there are Cargo.lock files, we need to run "cargo update --workspace" after all the Cargo.toml files have been edited.
 for DIR in ${CARGO_LOCKS} ; do
-    ( cd "${DIR}" && cargo update --workspace --offline)
+    ( cd "${DIR}" && cargo update --workspace)
     git add "${DIR}/Cargo.lock"
 done
 

--- a/.github/bump-version.set.sh
+++ b/.github/bump-version.set.sh
@@ -127,9 +127,9 @@ for FILE in ${VERSFILES} ; do
     fi
 done
 
-# If there are Cargo.lock files, we need to run "cargo generate-lockfile" after all the Cargo.toml files have been edited.
+# If there are Cargo.lock files, we need to run "cargo update --workspace" after all the Cargo.toml files have been edited.
 for DIR in ${CARGO_LOCKS} ; do
-    ( cd "${DIR}" && cargo generate-lockfile --offline )
+    ( cd "${DIR}" && cargo update --workspace --offline)
     git add "${DIR}/Cargo.lock"
 done
 

--- a/.github/bump-version.set.sh
+++ b/.github/bump-version.set.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# This script is copied from the depot repo; edit it there, not in the destination repo.
+
+# Set the semver in various files.
+
+# Always performs sanity checking:
+# - There must be at least one version file.
+# - The version must be a valid semver.
+# - The version must not be 0.0.0.
+# - After running, altered files must already be under Git control, and they must be only the version files we know how to handle,
+#   and modifications must be 0 or 1 line changes.
+
+# If setting the version to $a.$b.$c-$pre, substitute "SNAPSHOT" for $pre in any Java-related files.
+
+set -e
+
+# Parse args
+if [ $# -ne 1 ] ; then
+    echo "Usage: $0 version" 1>&2
+    exit 1
+fi
+NEWVERS="$1"
+
+# Sanity check: Ignoring any pre-release info, version must not be 0.0.0.
+if [ "${NEWVERS/-*/}" = "0.0.0" ] ; then
+    echo "Illegal zero version '${NEWVERS}'" 1>&2
+    exit 1
+fi
+# Sanity check: Must start with a valid semver, with an optional leading "v".
+if ! [[ ${NEWVERS} =~ ^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))? ]] ; then
+    echo "Invalid version '${NEWVERS}'" 1>&2
+    exit 1
+fi
+
+# Find the version files in this directory or its descendants, but don't recurse too deep.
+# This line must be kept in sync with "bump-version.get.sh".
+VERSFILES=$(find . -maxdepth 3 ! -path ./.git/\* | grep -v /node_modules/ | grep -E '.*/(version|Cargo.toml|version.go|package.json|pom.xml|version.sbt|build.gradle.kts)$')
+
+# Edit the version files.
+for FILE in ${VERSFILES} ; do
+    DIR=$(dirname "${FILE}")
+    case $(basename "${FILE}") in
+    version)
+        echo "${NEWVERS}" > "${FILE}"
+        ;;
+
+    Cargo.toml)
+        sed 's/^version = ".*"$/version = "'"${NEWVERS}"'"/' "${FILE}" > "${FILE}.tmp"
+        mv "${FILE}.tmp" "${FILE}"
+
+        # If there's a Cargo.lock, update it also.
+        if [ -f "${DIR}/Cargo.lock" ] ; then
+            CARGO_LOCKS="${CARGO_LOCKS} ${DIR}"
+        fi
+        ;;
+
+    version.go)
+        sed 's/const Version = ".*"/const Version = "'"${NEWVERS}"'"/' "${FILE}" > "${FILE}.tmp"
+        mv "${FILE}.tmp" "${FILE}"
+        ;;
+
+    package.json)
+        if [ "${DIR}" = "." ] ; then
+            # This is the root package.json, so we want .version.
+            jq --indent 4 ".version=\"${NEWVERS}\"" "${FILE}" > "${FILE}.new"
+        else
+            # Get the root package's name.
+            ROOTJSNAME="$(jq -re '.name' < package.json)"
+            jq --indent 4 ".dependencies[\"${ROOTJSNAME}\"]=\"^${NEWVERS}\"" "${FILE}" > "${FILE}.new"
+        fi
+        mv "${FILE}.new" "${FILE}"
+        ;;
+
+    pom.xml)
+        # Replace -foo with -SNAPSHOT to be compatible with Java conventions.
+        JAVAVERS="${NEWVERS/-*/-SNAPSHOT}"
+
+        if [ "${DIR}" = "." ] ; then
+            # This is the root pom.xml, so we want /m:project/m:version.
+            xmlstarlet ed -L -P -N m="http://maven.apache.org/POM/4.0.0" -u "/m:project/m:version" -v "${JAVAVERS}" "${FILE}"
+        else
+            # We've already computed our XPATH expression above, so reuse that here.
+            xmlstarlet ed -L -P -N m="http://maven.apache.org/POM/4.0.0" -u "${XPATH}" -v "${JAVAVERS}" "${FILE}"
+        fi
+        ;;
+
+    version.sbt)
+        # Replace -foo with -SNAPSHOT to be compatible with Java conventions.
+        # Disabling this logic to work with cmk-s3-proxy. Since we only use bump-version to publish our scala containers, not our
+        # scala libs, the -SNAPSHOT suffix isn't an important convention.
+        # JAVAVERS="${NEWVERS/-*/-SNAPSHOT}"
+        JAVAVERS="${NEWVERS}"
+
+        # The file might use the old, deprecated syntax or the newer syntax:
+        # version in ThisBuild := "1.2.3-SNAPSHOT"
+        # ThisBuild / version := "1.2.3-SNAPSHOT"
+        sed 's,^ThisBuild / version := ".*"$,ThisBuild / version := "'"${JAVAVERS}"'",' "${FILE}" > "${FILE}.tmp"
+        sed 's,^version in ThisBuild := ".*"$,ThisBuild / version := "'"${JAVAVERS}"'",' "${FILE}.tmp" > "${FILE}"
+        rm "${FILE}.tmp"
+        ;;
+
+    build.gradle.kts)
+        # Replace -foo with -SNAPSHOT to be compatible with Java conventions.
+        JAVAVERS="${NEWVERS/-*/-SNAPSHOT}"
+        sed 's/^version = ".*"$/version = "'"${JAVAVERS}"'"/' "${FILE}" > "${FILE}.tmp"
+        mv "${FILE}.tmp" "${FILE}"
+        ;;
+
+    *)
+        echo "Can't edit '${FILE}' with new version" 1>&2
+        exit 1
+    esac
+
+    # Add it to git.
+    git add "${FILE}"
+    # Verify that we've changed zero or one line.
+    git diff --cached -w --numstat "${FILE}" > /tmp/diffcount
+    if [ -s /tmp/diffcount ] ; then
+        # shellcheck disable=SC2034
+        read -r ADDED REMOVED FILENAME < /tmp/diffcount
+        if [ "${ADDED}" -ne 1 ] || [ "${REMOVED}" -ne 1 ] ; then
+            echo "Changes to '${FILE}' must be zero or one line, but observed edits are:" 1>&2
+            git diff --cached "${FILE}" 1>&2
+            exit 1
+        fi
+    fi
+done
+
+# If there are Cargo.lock files, we need to run "cargo fetch" after all the Cargo.toml files have been edited.
+for DIR in ${CARGO_LOCKS} ; do
+    ( cd "${DIR}" && cargo fetch )
+    git add "${DIR}/Cargo.lock"
+done
+
+# Look for files that have been changed, but that we haven't told git about.
+echo "Checking for modified but untracked files:"
+if git status -s | grep -qEv '^M ' ; then
+    echo "Modified but untracked files:" 1>&2
+    git status -s | grep -Ev '^M ' 1>&2
+    echo "This probably means '$0' modified a file but forgot to 'git add' it." 1>&2
+    exit 1
+fi

--- a/.github/bump-version.set.sh
+++ b/.github/bump-version.set.sh
@@ -127,9 +127,9 @@ for FILE in ${VERSFILES} ; do
     fi
 done
 
-# If there are Cargo.lock files, we need to run "cargo fetch" after all the Cargo.toml files have been edited.
+# If there are Cargo.lock files, we need to run "cargo generate-lockfile" after all the Cargo.toml files have been edited.
 for DIR in ${CARGO_LOCKS} ; do
-    ( cd "${DIR}" && cargo fetch )
+    ( cd "${DIR}" && cargo generate-lockfile --offline )
     git add "${DIR}/Cargo.lock"
 done
 

--- a/.github/bump-version.set.sh
+++ b/.github/bump-version.set.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# This script is copied from the depot repo; edit it there, not in the destination repo.
-
 # Set the semver in various files.
 
 # Always performs sanity checking:

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,0 +1,164 @@
+# This workflow does version management, bumping the patch version on the main branch after a PR is merged.
+
+# Requirements:
+# - It needs a GitHub secret named WORKFLOW_PAT with a personal access token that has workflow permissions. The user that owns the
+#   PAT must be allowed to push to the main branch of the repo. That usually means the user has to be a repo admin, and admins must
+#   be excepted from branch protection rules on main.
+# - Another workflow must consume the prereleases created by this one. That workflow should build and publish the release.
+
+# Terminology:
+# - In semver, everything before the optional "-" is the version, and everything after it is the prerelease version.
+# - In this workflow, we can operate on the release part of the semver, or on the prerelease part of the semver.
+# - In GitHub, we create a "release" object that can optionally have the "prerelease" flag set to true. The "docker.yaml" workflow
+#   triggers on release events.
+# I'm sorry the terminology is bad.
+
+# Customize:
+# It can work in either release mode or prerelease mode. That controls whether it increments the release version or the prerelease
+# version. Here's an example of how the two modes transform the current version into the release version and bumped version:
+# | mode    | release     | prerelease  |
+# | current | 1.2.3-pre   | 1.2.3-pre.4 |
+# | release | 1.2.3       | 1.2.3-rc.4  |
+# | bumped  | 1.2.4-pre   | 1.2.3-pre.5 |
+# The default mode is "release". To get "prerelease" mode, modify /env/MODE.
+
+# Details:
+# This workflow is triggered by merge to main, or by manual workflow_dispatch.
+# 1. Make a release version. Depending on whether we're in "release" or "prerelease" mode:
+#    - release: Remove the -prerelease info from the semver. (1.2.3-pre -> 1.2.3)
+#    - prerelease: Remove any non-numeric characters from the prerelease part of the semver. (1.2.3-pre.4 -> 1.2.3-4)
+# 2. Commit, push, tag, and create a GitHub prerelease.
+# 3. Bump the version, and add `-pre` or `.pre` as a pre-release identifier.
+#    - release: 1.2.3 -> 1.2.4-pre
+#    - prerelease: 1.2.3-4 -> 1.2.3-pre.5
+# 4. Commit and push.
+# It parses the version info from files in the repo like Cargo.toml, package.json, or version.sbt. It updates those files when it
+# bumps the version.
+# Sanity checks ensure it's a valid semver, and it's not 0.0.0.
+
+name: Bump Version
+
+on:
+  push:
+    branches:
+      # WARNING: Because this workflow pushes to main, we need more filtering in the job below to ensure we don't busy loop.
+      # The "[skip ci]" in the commit messages is important.
+      - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: New semver release version.
+        type: string
+        required: true
+      release_mode:
+        type: choice
+        options:
+          - release
+          - prerelease
+        required: false
+        default: release
+
+jobs:
+  # This job determines if we should run at all.
+  skip:
+    runs-on: ubuntu-22.04
+    outputs:
+      skip: ${{ steps.skip.outputs.skip }}
+    steps:
+      - name: Maybe skip
+        id: skip
+        run: |
+          # If it's a push to main, and any of the commits are from Dependabot, we should skip.
+          if [ ${{ github.event_name }} = push ] ; then
+            if [ $(jq -r < ${{ github.event_path }} '.commits | map(.author.name == "dependabot[bot]") | any') = true ] ; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+  bump:
+    needs:
+      - skip
+    runs-on: ubuntu-22.04
+    if: ${{ !needs.skip.outputs.skip }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.WORKFLOW_PAT }}
+      - name: Configure git
+        run: |
+          git config --global user.email ops@ironcorelabs.com
+          git config --global user.name "Leeroy Travis"
+      - name: Release
+        id: release
+        # Because the last step of this can race against other runs of this workflow, we need to retry in a loop.
+        run: |
+          set -x
+          RETRIES=10
+          TRY=0
+          while [ $TRY -lt $RETRIES ] ; do
+            TRY=$(expr $TRY + 1)
+            # Get the current version.
+            CURRENT=$(.github/bump-version.get.sh)
+            # Calculate next release version, and next dev version. Output to $GITHUB_OUTPUT, which we then read.
+            .github/bump-version.bump.sh "${{ inputs.release_mode }}" "${CURRENT}" ${{ inputs.version }}
+            . $GITHUB_OUTPUT
+            # Set the in-tree version to the release version.
+            .github/bump-version.set.sh "${release}"
+            git diff --cached
+            # GHA intermixes the stdout from git diff with stderr from "set -x", so we pause to let it settle.
+            sleep 1
+            git commit -m "Set release version ${release} [skip ci]"
+            git tag "${release}"
+
+            # Bump to the next development version.
+            .github/bump-version.set.sh "${bumped}"
+            git diff --cached
+            sleep 1
+            git commit -m "Bump to next development version ${bumped} [skip ci]"
+
+            # If we push the release commit and its tag in one step, we hit strange race conditions where one client succeeds
+            # pushing the tag, and another client succeeds pushing the commit. Instead, we push the commit first and then the tag.
+            # That seems to cause the loser of the race to fail early.
+            if git push origin "${{ github.ref }}" && git push origin "${release}" ; then
+              # Just exit.
+              exit 0
+            fi
+
+            # If the "git push" failed, then let's forget our last two commits, re-pull the latest changes, and try again.
+            git reset --hard HEAD~2
+            git tag -d "${release}"
+            git pull origin "${{ github.ref }}"
+            # Wait a little bit to let competing workflows finish their business.
+            sleep 10
+          done
+          # Fallthrough for repeated failure case.
+          echo "Failed to push bumped versions; tried $TRY times."
+          exit 1
+      - name: Generate release text
+        id: release-body
+        run: |
+          set -x
+          # Get the most recent commit. Hopefully it was a PR merge.
+          COMMIT=$(jq -r '.after' ${{ github.event_path }})
+          if [ "${COMMIT}" = "null" ] || [ -z "${COMMIT}" ] ; then
+            exit 0
+          fi
+          # Get the most recent PRs; hopefully ours is one of them.
+          curl -fSs -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.WORKFLOW_PAT }}" \
+            https://api.github.com/repos/${{ github.repository }}/pulls?state=all\&base=${{ github.ref }}\&sort=updated\&direction=desc > /tmp/prs.json
+          # Find a PR that resulted in our commit.
+          PR=$(jq -r ".[] | select(.merge_commit_sha == \"${COMMIT}\") | .number" /tmp/prs.json)
+          if [ "${PR}" = "null" ] || [ -z "${PR}" ] ; then
+            exit 0
+          fi
+          # Build the string we'll use as the description of the release.
+          echo "body=latest_pr:${PR}" >> "$GITHUB_OUTPUT"
+      - name: Create prerelease
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.WORKFLOW_PAT }}
+          prerelease: true
+          tag: ${{ steps.release.outputs.release }}
+          body: "${{ steps.release-body.outputs.body }}"

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -23,7 +23,7 @@
 # The default mode is "release". To get "prerelease" mode, modify /env/MODE.
 
 # Details:
-# This workflow is triggered by merge to main, or by manual workflow_dispatch.
+# With our typical triggers, this workflow is triggered by merge to main, or by manual workflow_dispatch.
 # 1. Make a release version. Depending on whether we're in "release" or "prerelease" mode:
 #    - release: Remove the -prerelease info from the semver. (1.2.3-pre -> 1.2.3)
 #    - prerelease: Remove any non-numeric characters from the prerelease part of the semver. (1.2.3-pre.4 -> 1.2.3-4)
@@ -39,11 +39,6 @@
 name: Bump Version
 
 on:
-  # push:
-  #   branches:
-  #     # WARNING: Because this workflow pushes to main, we need more filtering in the job below to ensure we don't busy loop.
-  #     # The "[skip ci]" in the commit messages is important.
-  #     - main
   workflow_call:
     inputs:
       version:
@@ -51,9 +46,15 @@ on:
         type: string
         required: true
       release_mode:
+        description: Whether to increment the release number (1.2.3 -> 1.2.4-pre) or the prerelease number (1.2.3-4 -> 1.2.3-pre.5). Defaults to "release".
         type: string
         required: false
         default: release
+      release_prereleases:
+        description: Whether to make a GitHub release for each prerelease version. Defaults to `true`.
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   # This job determines if we should run at all.
@@ -163,9 +164,19 @@ jobs:
           echo "body=latest_pr:${PR}" >> "$GITHUB_OUTPUT"
         working-directory: self
       - name: Create prerelease
+        # If the release isn't a prerelease version OR you want to make releases for prerelease versions
+        if: ${{ !contains(steps.release.outputs.release, '-') || inputs.release_prereleases }}
+        id: github-release
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.WORKFLOW_PAT }}
           prerelease: true
           tag: ${{ steps.release.outputs.release }}
           body: "${{ steps.release-body.outputs.body }}"
+      - name: Trigger Docker
+        if: steps.github-release.outcome == 'skipped'
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Docker
+          inputs: '{ "ref": "${{ steps.release.outputs.release }}", "tags": "${{ steps.release.outputs.release }}" }'
+          token: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -55,6 +55,11 @@ on:
         type: boolean
         required: false
         default: true
+      configure_git_ssh:
+        description: Whether to configure git ssh with LEEROY_PRIVATE_SSH_KEY repository secret.
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   # This job determines if we should run at all.
@@ -95,6 +100,14 @@ jobs:
         run: |
           git config --global user.email ops@ironcorelabs.com
           git config --global user.name "Leeroy Travis"
+      - name: Configure git ssh access
+        if: inputs.configure_git_ssh
+        run: |
+          mkdir -p "${HOME}/.ssh"
+          chmod 700 "${HOME}/.ssh"
+          echo '${{ secrets.LEEROY_PRIVATE_SSH_KEY }}' > "${HOME}/.ssh/id_ed25519"
+          chmod 600 "${HOME}/.ssh/id_ed25519"
+          ssh-keyscan github.com > "${HOME}/.ssh/known_hosts"
       - name: Release
         id: release
         # Because the last step of this can race against other runs of this workflow, we need to retry in a loop.

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -79,8 +79,7 @@ jobs:
           fi
 
   bump:
-    needs:
-      - skip
+    needs: skip
     runs-on: ubuntu-22.04
     if: ${{ !needs.skip.outputs.skip }}
     steps:
@@ -174,7 +173,7 @@ jobs:
         # If the release isn't a prerelease version OR you want to make releases for prerelease versions
         if: ${{ !contains(steps.release.outputs.release, '-') || inputs.release_prereleases }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: gh release create "${{ steps.release.outputs.release }}" --prerelease=true --notes "${{ steps.release-body.outputs.body }}"
         working-directory: self
       - name: Trigger Docker

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: IronCoreLabs/workflows
-          ref: bump-version-workflow
+          ref: ${{ github.action_ref }}
           token: ${{ secrets.WORKFLOW_PAT }}
           path: workflows
       - name: Configure git

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -78,12 +78,17 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ !needs.skip.outputs.skip }}
     steps:
-      - name: Checkout
+      - name: Checkout own repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.WORKFLOW_PAT }}
+      - name: Checkout workflows repo
         uses: actions/checkout@v4
         with:
           repository: IronCoreLabs/workflows
           ref: bump-version-workflow
           token: ${{ secrets.WORKFLOW_PAT }}
+          path: workflows
       - name: Configure git
         run: |
           git config --global user.email ops@ironcorelabs.com
@@ -98,12 +103,12 @@ jobs:
           while [ $TRY -lt $RETRIES ] ; do
             TRY=$(expr $TRY + 1)
             # Get the current version.
-            CURRENT=$(.github/bump-version.get.sh)
+            CURRENT=$(workflow/.github/bump-version.get.sh)
             # Calculate next release version, and next dev version. Output to $GITHUB_OUTPUT, which we then read.
-            .github/bump-version.bump.sh "${{ inputs.release_mode }}" "${CURRENT}" ${{ inputs.version }}
+            workflows/.github/bump-version.bump.sh "${{ inputs.release_mode }}" "${CURRENT}" ${{ inputs.version }}
             . $GITHUB_OUTPUT
             # Set the in-tree version to the release version.
-            .github/bump-version.set.sh "${release}"
+            workflows/.github/bump-version.set.sh "${release}"
             git diff --cached
             # GHA intermixes the stdout from git diff with stderr from "set -x", so we pause to let it settle.
             sleep 1
@@ -111,7 +116,7 @@ jobs:
             git tag "${release}"
 
             # Bump to the next development version.
-            .github/bump-version.set.sh "${bumped}"
+            workflows/.github/bump-version.set.sh "${bumped}"
             git diff --cached
             sleep 1
             git commit -m "Bump to next development version ${bumped} [skip ci]"

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -103,7 +103,7 @@ jobs:
           while [ $TRY -lt $RETRIES ] ; do
             TRY=$(expr $TRY + 1)
             # Get the current version.
-            CURRENT=$(workflow/.github/bump-version.get.sh)
+            CURRENT=$(workflows/.github/bump-version.get.sh)
             # Calculate next release version, and next dev version. Output to $GITHUB_OUTPUT, which we then read.
             workflows/.github/bump-version.bump.sh "${{ inputs.release_mode }}" "${CURRENT}" ${{ inputs.version }}
             . $GITHUB_OUTPUT

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -55,6 +55,10 @@ on:
         type: boolean
         required: false
         default: true
+      workflows_ref:
+        description: Set to github.action_ref variable.
+        type: string
+        required: true
 
 jobs:
   # This job determines if we should run at all.
@@ -88,7 +92,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: IronCoreLabs/workflows
-          ref: ${{ github.workflow_ref }}
+          ref: ${{ inputs.workflows_ref }}
           token: ${{ secrets.WORKFLOW_PAT }}
           path: workflows
       - name: Configure git

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -150,7 +150,6 @@ jobs:
         id: release-body
         run: |
           set -x
-          cat ${{ github.event_path }}
           # Get the most recent commit. Hopefully it was a PR merge.
           COMMIT=$(jq -r '.after' ${{ github.event_path }})
           if [ "${COMMIT}" = "null" ] || [ -z "${COMMIT}" ] ; then
@@ -175,7 +174,7 @@ jobs:
         if: ${{ !contains(steps.release.outputs.release, '-') || inputs.release_prereleases }}
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
-        run: gh release create "${{ steps.release.outputs.release }}" --prerelease=true --notes "${{ steps.release-body.outputs.body }}"
+        run: gh release create "${{ steps.release.outputs.release }}" --title "${{ steps.release.outputs.release }}" --prerelease=true --notes "${{ steps.release-body.outputs.body }}"
         working-directory: self
       - name: Trigger Docker
         # If we didn't make a GitHub Release, we need to trigger the Docker workflow manually

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -39,22 +39,19 @@
 name: Bump Version
 
 on:
-  push:
-    branches:
-      # WARNING: Because this workflow pushes to main, we need more filtering in the job below to ensure we don't busy loop.
-      # The "[skip ci]" in the commit messages is important.
-      - main
-  workflow_dispatch:
+  # push:
+  #   branches:
+  #     # WARNING: Because this workflow pushes to main, we need more filtering in the job below to ensure we don't busy loop.
+  #     # The "[skip ci]" in the commit messages is important.
+  #     - main
+  workflow_call:
     inputs:
       version:
         description: New semver release version.
         type: string
         required: true
       release_mode:
-        type: choice
-        options:
-          - release
-          - prerelease
+        type: string
         required: false
         default: release
 

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -56,7 +56,7 @@ on:
         required: false
         default: true
       workflows_ref:
-        description: Set to github.action_ref variable.
+        description: Ref for the `workflows` repo. This should match the ref from the `uses` (after the @ symbol).
         type: string
         required: true
 

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -176,6 +176,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release create "${{ steps.release.outputs.release }}" --prerelease=true --notes "${{ steps.release-body.outputs.body }}"
+        working-directory: self
       - name: Trigger Docker
         # If we didn't make a GitHub Release, we need to trigger the Docker workflow manually
         if: steps.github-release.outcome == 'skipped'

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -42,7 +42,7 @@ on:
   workflow_call:
     inputs:
       version:
-        description: New semver release version.
+        description: Semver release version from caller's workflow_dispatch. Should be set to `inputs.version` variable, or empty string if doesn't exist.
         type: string
         required: true
       release_mode:
@@ -55,10 +55,11 @@ on:
         type: boolean
         required: false
         default: true
-      workflows_ref:
-        description: Ref for the `workflows` repo. This should match the ref from the `uses` (after the @ symbol).
+      workflows_repo_ref:
+        description: Ref for `workflows` repo to check out. Defaults to tag `bump-version-v1`.
         type: string
-        required: true
+        required: false
+        default: "bump-version-v1"
 
 jobs:
   # This job determines if we should run at all.
@@ -92,7 +93,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: IronCoreLabs/workflows
-          ref: ${{ inputs.workflows_ref }}
+          ref: ${{ inputs.workflows_repo_ref }}
           token: ${{ secrets.WORKFLOW_PAT }}
           path: workflows
       - name: Configure git
@@ -167,17 +168,16 @@ jobs:
           # Build the string we'll use as the description of the release.
           echo "body=latest_pr:${PR}" >> "$GITHUB_OUTPUT"
         working-directory: self
-      - name: Create prerelease
+      # This triggers the Docker workflow's `release: created`
+      - name: Create GitHub Release
+        id: github-release
         # If the release isn't a prerelease version OR you want to make releases for prerelease versions
         if: ${{ !contains(steps.release.outputs.release, '-') || inputs.release_prereleases }}
-        id: github-release
-        uses: ncipollo/release-action@v1
-        with:
-          token: ${{ secrets.WORKFLOW_PAT }}
-          prerelease: true
-          tag: ${{ steps.release.outputs.release }}
-          body: "${{ steps.release-body.outputs.body }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ steps.release.outputs.release }}" --prerelease=true --notes "${{ steps.release-body.outputs.body }}"
       - name: Trigger Docker
+        # If we didn't make a GitHub Release, we need to trigger the Docker workflow manually
         if: steps.github-release.outcome == 'skipped'
         uses: benc-uk/workflow-dispatch@v1
         with:

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -55,11 +55,6 @@ on:
         type: boolean
         required: false
         default: true
-    #   configure_git_ssh:
-    #     description: Whether to configure git ssh with LEEROY_PRIVATE_SSH_KEY repository secret.
-    #     type: boolean
-    #     required: false
-    #     default: false
 
 jobs:
   # This job determines if we should run at all.
@@ -100,14 +95,6 @@ jobs:
         run: |
           git config --global user.email ops@ironcorelabs.com
           git config --global user.name "Leeroy Travis"
-      #   - name: Configure git ssh access
-      #     if: inputs.configure_git_ssh
-      #     run: |
-      #       mkdir -p "${HOME}/.ssh"
-      #       chmod 700 "${HOME}/.ssh"
-      #       echo '${{ secrets.LEEROY_PRIVATE_SSH_KEY }}' > "${HOME}/.ssh/id_ed25519"
-      #       chmod 600 "${HOME}/.ssh/id_ed25519"
-      #       ssh-keyscan github.com > "${HOME}/.ssh/known_hosts"
       - name: Release
         id: release
         # Because the last step of this can race against other runs of this workflow, we need to retry in a loop.

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -55,11 +55,11 @@ on:
         type: boolean
         required: false
         default: true
-      configure_git_ssh:
-        description: Whether to configure git ssh with LEEROY_PRIVATE_SSH_KEY repository secret.
-        type: boolean
-        required: false
-        default: false
+    #   configure_git_ssh:
+    #     description: Whether to configure git ssh with LEEROY_PRIVATE_SSH_KEY repository secret.
+    #     type: boolean
+    #     required: false
+    #     default: false
 
 jobs:
   # This job determines if we should run at all.
@@ -100,14 +100,14 @@ jobs:
         run: |
           git config --global user.email ops@ironcorelabs.com
           git config --global user.name "Leeroy Travis"
-      - name: Configure git ssh access
-        if: inputs.configure_git_ssh
-        run: |
-          mkdir -p "${HOME}/.ssh"
-          chmod 700 "${HOME}/.ssh"
-          echo '${{ secrets.LEEROY_PRIVATE_SSH_KEY }}' > "${HOME}/.ssh/id_ed25519"
-          chmod 600 "${HOME}/.ssh/id_ed25519"
-          ssh-keyscan github.com > "${HOME}/.ssh/known_hosts"
+      #   - name: Configure git ssh access
+      #     if: inputs.configure_git_ssh
+      #     run: |
+      #       mkdir -p "${HOME}/.ssh"
+      #       chmod 700 "${HOME}/.ssh"
+      #       echo '${{ secrets.LEEROY_PRIVATE_SSH_KEY }}' > "${HOME}/.ssh/id_ed25519"
+      #       chmod 600 "${HOME}/.ssh/id_ed25519"
+      #       ssh-keyscan github.com > "${HOME}/.ssh/known_hosts"
       - name: Release
         id: release
         # Because the last step of this can race against other runs of this workflow, we need to retry in a loop.

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: IronCoreLabs/workflows
+          ref: bump-version-workflow
           token: ${{ secrets.WORKFLOW_PAT }}
       - name: Configure git
         run: |

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -81,6 +81,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: IronCoreLabs/workflows
           token: ${{ secrets.WORKFLOW_PAT }}
       - name: Configure git
         run: |

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.WORKFLOW_PAT }}
+          path: self
       - name: Checkout workflows repo
         uses: actions/checkout@v4
         with:
@@ -103,12 +104,12 @@ jobs:
           while [ $TRY -lt $RETRIES ] ; do
             TRY=$(expr $TRY + 1)
             # Get the current version.
-            CURRENT=$(workflows/.github/bump-version.get.sh)
+            CURRENT=$(../workflows/.github/bump-version.get.sh)
             # Calculate next release version, and next dev version. Output to $GITHUB_OUTPUT, which we then read.
-            workflows/.github/bump-version.bump.sh "${{ inputs.release_mode }}" "${CURRENT}" ${{ inputs.version }}
+            ../workflows/.github/bump-version.bump.sh "${{ inputs.release_mode }}" "${CURRENT}" ${{ inputs.version }}
             . $GITHUB_OUTPUT
             # Set the in-tree version to the release version.
-            workflows/.github/bump-version.set.sh "${release}"
+            ../workflows/.github/bump-version.set.sh "${release}"
             git diff --cached
             # GHA intermixes the stdout from git diff with stderr from "set -x", so we pause to let it settle.
             sleep 1
@@ -116,7 +117,7 @@ jobs:
             git tag "${release}"
 
             # Bump to the next development version.
-            workflows/.github/bump-version.set.sh "${bumped}"
+            ../workflows/.github/bump-version.set.sh "${bumped}"
             git diff --cached
             sleep 1
             git commit -m "Bump to next development version ${bumped} [skip ci]"
@@ -139,6 +140,7 @@ jobs:
           # Fallthrough for repeated failure case.
           echo "Failed to push bumped versions; tried $TRY times."
           exit 1
+        working-directory: self
       - name: Generate release text
         id: release-body
         run: |
@@ -159,6 +161,7 @@ jobs:
           fi
           # Build the string we'll use as the description of the release.
           echo "body=latest_pr:${PR}" >> "$GITHUB_OUTPUT"
+        working-directory: self
       - name: Create prerelease
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: IronCoreLabs/workflows
-          ref: ${{ github.action_ref }}
+          ref: ${{ github.workflow_ref }}
           token: ${{ secrets.WORKFLOW_PAT }}
           path: workflows
       - name: Configure git

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -150,6 +150,7 @@ jobs:
         id: release-body
         run: |
           set -x
+          cat ${{ github.event_path }}
           # Get the most recent commit. Hopefully it was a PR merge.
           COMMIT=$(jq -r '.after' ${{ github.event_path }})
           if [ "${COMMIT}" = "null" ] || [ -z "${COMMIT}" ] ; then

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -84,8 +84,6 @@ jobs:
       longtag: ${{ steps.tag.outputs.longest }}
       runners: ${{ steps.archs.outputs.runners }}
     steps:
-      - name: Print event
-        run: cat ${{ github.event_path }}
       - name: Set docker image tags
         id: tag
         run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -84,6 +84,8 @@ jobs:
       longtag: ${{ steps.tag.outputs.longest }}
       runners: ${{ steps.archs.outputs.runners }}
     steps:
+      - name: Print event
+        run: cat ${{ github.event_path }}
       - name: Set docker image tags
         id: tag
         run: |


### PR DESCRIPTION
The only change I made to the `.sh` files:
- Instead of doing `cargo fetch`, I changed it to `cargo update --workspace`. I think that this will make it so we don't need git ssh creds for the bump version workflow.
