### PR TITLE
Use the git tag as the base for the docker tag.

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -89,7 +89,7 @@ jobs:
         run: |
           if [ -n "${{ github.event.release.name }}" ] ; then
             # If TAG is 1.2.3, set TAGS to "1.2.3 1.2 1".
-            TAG="${{ github.event.release.name }}"
+            TAG="${{ github.event.release.tag_name }}"
             while ! [ -z "${TAG}" ] ; do
               TAGS="${TAGS} ${TAG}"
               TAG=$(echo ${TAG} | sed -E 's,\.?[^.]+$,,')


### PR DESCRIPTION
When we pick a name for the tag of the container image, we base it on the name of the software release that the container image is built from. This PR changes it to use the git tag name instead of the release name. In most cases these will be the same, but it seems more correct to use the git tag. That would allow us to give human-readable names to releases, if we thought that was desirable.

A recent bug in the `bump-version` workflow caused the `docker` workflow to misbehave by reading a null release title. This PR would have prevented that problem.