### PR TITLE
Retry "gh pr checks --watch".

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -196,7 +196,16 @@ jobs:
         echo "This PR should only modify non-production files, and it should be auto-approved shortly." >> /tmp/body.txt
         echo "Once it's auto-approved, it should auto-merge." >> /tmp/body.txt
         gh pr create --assignee @me --fill --body-file /tmp/body.txt
-        gh pr checks --watch --required
+        # Avoid a race condition with checks not existing immediately upon PR creation.
+        TRY=1
+        while ! gh pr checks --watch --required ; do
+          sleep 10
+          TRY=$(expr $TRY + 1)
+          if [ $TRY -ge 30 ] ; then
+            echo "Failed to wait for PR checks."
+            exit 1
+          fi
+        done
         gh pr merge --admin --squash
 
     # Comment on the original software PR, pointing to the new deployments PR.


### PR DESCRIPTION
In [this run](https://github.com/IronCoreLabs/actions-test/actions/runs/6645667065/job/18057477045), the error was:
```
no checks reported on the 'test-actions-test-1.2.50' branch
```

I'm just guessing it's a race condition that can be addressed by waiting and retrying.