### PR TITLE
Skip converting to PDF

### DIFF
--- a/.github/workflows/scala-cve.yaml
+++ b/.github/workflows/scala-cve.yaml
@@ -23,8 +23,7 @@ jobs:
       run: echo "file_name=$(date +%B)-${GITHUB_REPOSITORY#*/}-cve.pdf" >> $GITHUB_OUTPUT
     - name: Set run_url output var
       id: run_url
-      run: |
-        echo "run_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+      run: echo "run_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
     - uses: coursier/setup-action@v1
       with:
         jvm: adopt:11
@@ -34,21 +33,15 @@ jobs:
         MAVEN_IRONCORELABS_COM_AWS_ACCESS_KEY_ID: ${{ secrets.MAVEN_IRONCORELABS_COM_AWS_ACCESS_KEY_ID }}
         MAVEN_IRONCORELABS_COM_AWS_SECRET_KEY: ${{ secrets.MAVEN_IRONCORELABS_COM_AWS_SECRET_KEY }}
       run: sbt -Dhttps.protocols=TLSv1.2,TLSv1.1,TLSv1 dependencyCheckAggregate
-    - name: Convert HTML report to PDF
-      uses: fifsky/html-to-pdf-action@v0.1.0
-      with:
-        htmlFile: ./target/scala-2.13/dependency-check-report.html
-        outputFile: ./${{ steps.file_name.outputs.file_name }}
-        pdfOptions: '{"format": "A4", "margin": {"top": "10mm", "left": "10mm", "right": "10mm", "bottom": "10mm"}}'
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.file_name.outputs.file_name }}
-        path: ${{ steps.file_name.outputs.file_name }}
+        path: ./target/scala-2.13/dependency-check-report.html
     - run: |
         curl -Ss -X POST \
         -H "Authorization: token ${{ secrets.WORKFLOW_PAT }}" \
         -H "Accept: application/vnd.github.v3+json" \
         -d "{\"title\": \"CVE Check $(date +"%B %Y")\",
-          \"body\": \"Output is attached as an artifact to ${{ steps.run_url.outputs.run_url }}. Please attach it to this issue and open a new issue for remediation, if necessary.\"
+          \"body\": \"Output is attached as an artifact to ${{ steps.run_url.outputs.run_url }}. Please attach it to this issue and assign a point value for remediation, if necessary.\"
           }" \
         https://api.github.com/repos/${{ github.repository }}/issues


### PR DESCRIPTION
The action we were using to convert to PDF suddenly stopped working. There's an issue open for it, but no response from the developer or workarounds given. I looked into alternatives briefly, but it didn't seem worth the effort. So we'll just skip the PDF conversion altogether.