### PR TITLE
Git config before git commit.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -197,6 +197,8 @@ jobs:
       if: "${{ steps.update-depot.outputs.changed == 'true' }}"
       working-directory: depot
       run: |
+        git config --global user.email ops@ironcorelabs.com
+        git config --global user.name "Leeroy Travis"
         COMMIT_MSG="Upgrade local-dev-cluster: [ ${THISREPO} -> ${{ inputs.tag }} ]"
         git commit -m "${COMMIT_MSG}"
         TRIES=0


### PR DESCRIPTION
This avoids problems like [this](https://github.com/IronCoreLabs/admin-console/actions/runs/6787597627/job/18450740041):
```
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az370-881.3txz4wqopyzepmqexx20lynywb.cx.internal.cloudapp.net>) not allowed
```