### PR TITLE
Use the most precise version we can find.

### DIFF
--- a/.github/bump-version.bump.sh
+++ b/.github/bump-version.bump.sh
@@ -47,7 +47,7 @@ if [ -z "${RELEASEVERS}" ] ; then
         ;;
     "prerelease")
         # Replace [-.]pre[-.$] with [-.]rc[-.$].
-        RELEASEVERS="$(echo "${CURRENTVERS}" | sed -E 's/([-.])pre([-.]|$)/\1rc\2/')"
+        RELEASEVERS="$(echo "${CURRENTVERS}" | sed -E 's/([-.])(pre|SNAPSHOT)([-.]|$)/\1rc\3/')"
         # If no [-.]rc[-.$], append -rc.0.
         if ! [[ ${RELEASEVERS} =~ [-.]rc([-.]|$) ]] ; then
             RELEASEVERS="${RELEASEVERS}-rc.0"

--- a/.github/bump-version.get.sh
+++ b/.github/bump-version.get.sh
@@ -88,6 +88,10 @@ for FILE in ${VERSFILES} ; do
     if [ -z "${CURRENTVERS}" ] ; then
         CURRENTVERS="${VERS}"
     fi
+    # If this version is more precise than current version, set current version.
+    if [[ ${CURRENTVERS} =~ -SNAPSHOT$ ]] && ! [[ ${VERS} =~ -SNAPSHOT$ ]] ; then
+        CURRENTVERS="${VERS}"
+    fi
 
     # Compare this file's version to other files' version. Ignore anything after the "-" in a pre-release version, but keep the "-"
     # so a release version is unequal to a pre-release.

--- a/.github/spec/bump_spec.sh
+++ b/.github/spec/bump_spec.sh
@@ -19,11 +19,13 @@ Describe 'bump-version.bump.sh'
             "r#5" release    1.2.9-pre         1.2.9            1.2.10-pre
             "r#6" release    1.2.0-pre         1.2.0            1.2.1-pre
             "r#7" release    0.1.119-pre       0.1.119          0.1.120-pre
+            "r#8" release    1.2.3-SNAPSHOT    1.2.3            1.2.4-pre
             "p#1" prerelease 1.2.3-pre.4       1.2.3-rc.4       1.2.3-pre.5
             "p#2" prerelease 1.2.3-pre.4.5.6   1.2.3-rc.4.5.6   1.2.3-pre.4.5.7
             "p#3" prerelease 1.2.3-pre         1.2.3-rc.0       1.2.3-pre.1
             "p#4" prerelease 1.2.3             1.2.3-rc.0       1.2.3-pre.1
             "p#5" prerelease 1.2.3_p4-r5-pre.1 1.2.3_p4-r5-rc.1 1.2.3_p4-r5-pre.2
+            "p#6" prerelease 1.2.3-SNAPSHOT    1.2.3-rc.0       1.2.3-pre.1
         End
         It "example $1"
             When call testit "$2" "$3"


### PR DESCRIPTION
In `bump-version.get.sh`, the `find` command on line 21 returns files in a nondeterministic order. If the first file it finds is a Java ecosystem file, it'll decide the version is something like `0.9.0-SNAPSHOT`. If it later finds a file with more accurate version information, like a `Cargo.toml` with something like `0.9.0-pre.3`, then it'll decide those version strings are compatible with each other and keep the first one it found.

If that string is fed to `bump-version.bump.sh`, which is how the `bump-version.yaml` workflow works, then it'll append `-pre.1` to make a new version.

This PR fixes `bump-version.get.sh` so it will produce the same output regardless of which order the files are found. It also fixes `bump-version.bump.sh` to behave in a sane manner if the only version found is a `-SNAPSHOT` version.