### PR TITLE
Avoid mangled regex reference.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -185,7 +185,7 @@ jobs:
             IMG_NAME="${{ inputs.image-override }}"
           fi
           if grep "${IMG_NAME}" Tiltfile ; then
-            sed "s,\(FROM ${IMG_NAME}:\)[a-zA-Z0-9_.-]*,\\1${{ inputs.tag }}," < Tiltfile > Tiltfile.new
+            sed "s,\(FROM ${IMG_NAME}\):[a-zA-Z0-9_.-]*,\\1:${{ inputs.tag }}," < Tiltfile > Tiltfile.new
             mv Tiltfile.new Tiltfile
             touch /tmp/changed-depot
           fi


### PR DESCRIPTION
In [this build](https://github.com/IronCoreLabs/tenant-security-proxy/actions/runs/6896796136/job/18763635097), it failed to update `Tiltfile` for `local-dev-cluster` in `depot`. The sed expression creates a capture group consisting of the image name and the colon before the tag, e.g. `gcr.io/ironcore-images/tenant-security-proxy:`. It tries to use a replacement expression of `\1${{ inputs.tag }}`. But if `${{ inputs.tag }}` starts with a number (e.g., `4.12.0`), then it mangles the replacement expression into `\14.12.0`. And since there's no 14th capture group in the sed expression, it silently fails to replace.

This PR moves the colon outside of the capture group because I don't know how to escape a capture group in sed, and the `:` serves as a separator.