### PR TITLE
Push all the docker tags.

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -329,6 +329,8 @@ jobs:
               fi
             done
             if docker manifest create "${{ steps.name.outputs.canonical }}" ${IMGS} ; then
+              # We'll re-create this below, in the loop.
+              docker manifest rm "${{ steps.name.outputs.canonical }}"
               break
             fi
             echo "Attempt #${RETRY} failed."

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -317,6 +317,7 @@ jobs:
       - name: Create and push manifest
         run: |
           set -x
+          IMGS=$(echo ${{ inputs.archs }} | tr ' ' '\n' | sed 's%^%${{ steps.name.outputs.canonical }}-%' | tr '\n' ' ')
           # Sometimes GCR gives random errors. Let's try a few times before giving up.
           for RETRY in $(seq 10) ; do
             for ARCH in ${{ inputs.archs }} ; do
@@ -327,14 +328,17 @@ jobs:
                 continue 2
               fi
             done
-            IMGS=$(echo ${{ inputs.archs }} | tr ' ' '\n' | sed 's%^%${{ steps.name.outputs.canonical }}-%' | tr '\n' ' ')
             if docker manifest create "${{ steps.name.outputs.canonical }}" ${IMGS} ; then
               break
             fi
             echo "Attempt #${RETRY} failed."
             sleep 10
           done
-          docker manifest push "${{ steps.name.outputs.canonical }}"
+          # If that worked, we should be able to create each of the aliases (e.g. 4.12.0, 4.12, 4).
+          for IMAGE in ${{ needs.image.outputs.images }} ; do
+            docker manifest create "$IMAGE" ${IMGS}
+            docker manifest push "$IMAGE"
+          done
       # This triggers the Deploy workflow's `release: released`
       - name: Mark GitHub release as not prerelease
         if: github.event.release != null && inputs.update_github_release


### PR DESCRIPTION
In the `image` job, we calculate all the tags we eventually want to push. But then in the `publish` job, we only push the longest tag. This PR changes it to push all of them.