### PR TITLE
Upgrade to rust-install v0.1.2, make secrets optional for Rust workflows

### DIFF
--- a/.github/workflows/rust-artifact.yaml
+++ b/.github/workflows/rust-artifact.yaml
@@ -57,6 +57,9 @@ on:
 jobs:
   cargo-artifact:
     runs-on: ${{ matrix.os }}
+    env:
+      SCCACHE_AWS_SECRET: ${{ secrets.SCCACHE_AWS_SECRET }}
+      TOOL_CACHE_SECRET_KEY: ${{ secrets.TOOL_CACHE_SECRET_KEY }}
     strategy:
       fail-fast: false
       matrix:
@@ -83,21 +86,21 @@ jobs:
         with:
           targets: ${{ matrix.rust_target }}
       - name: Install sccache
-        if: ${{ secrets.SCCACHE_AWS_SECRET != '' }}
+        if: env.SCCACHE_AWS_SECRET != ''
         uses: IronCoreLabs/rust-install@v0.1.2
         with:
           crate: sccache
           accesskey: AKIAU2WBY6VDTC563V7G
-          secretkey: ${{ secrets.TOOL_CACHE_SECRET_KEY }}
+          secretkey: ${{ env.TOOL_CACHE_SECRET_KEY }}
           os: ${{ join(matrix.os) }}
           version: latest
       - name: Setup sccache env variables
-        if: ${{ secrets.SCCACHE_AWS_SECRET != '' }}
+        if: env.SCCACHE_AWS_SECRET != ''
         run: |
           echo "CC=$(which cc)" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=$HOME/.cargo/bin/sccache" >> $GITHUB_ENV
           echo "AWS_ACCESS_KEY_ID=AKIAU2WBY6VDVHUO5WSN" >> $GITHUB_ENV
-          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.SCCACHE_AWS_SECRET }}" >> $GITHUB_ENV
+          echo "AWS_SECRET_ACCESS_KEY=${{ env.SCCACHE_AWS_SECRET }}" >> $GITHUB_ENV
           echo "SCCACHE_BUCKET=sccache-rust" >> $GITHUB_ENV
           echo "SCCACHE_S3_USE_SSL=true" >> $GITHUB_ENV
           echo "SCCACHE_REGION=us-west-2" >> $GITHUB_ENV
@@ -125,4 +128,5 @@ jobs:
             ${{ steps.rust_root.outputs.rust_root }}/target/${{ inputs.build_profile }}/*.so
           if-no-files-found: error
       - name: Print sccache stats
+        if: env.SCCACHE_AWS_SECRET != ''
         run: sccache -s

--- a/.github/workflows/rust-artifact.yaml
+++ b/.github/workflows/rust-artifact.yaml
@@ -49,10 +49,10 @@ on:
     secrets:
       TOOL_CACHE_SECRET_KEY:
         description: "AWS secret key to access our Rust tool cache S3 bucket."
-        required: true
+        required: false
       SCCACHE_AWS_SECRET:
         description: "AWS secret key to access our sccache S3 bucket."
-        required: true
+        required: false
 
 jobs:
   cargo-artifact:
@@ -83,7 +83,8 @@ jobs:
         with:
           targets: ${{ matrix.rust_target }}
       - name: Install sccache
-        uses: IronCoreLabs/rust-install@v0.1.0
+        if: ${{ secrets.SCCACHE_AWS_SECRET != '' }}
+        uses: IronCoreLabs/rust-install@v0.1.2
         with:
           crate: sccache
           accesskey: AKIAU2WBY6VDTC563V7G
@@ -91,6 +92,7 @@ jobs:
           os: ${{ join(matrix.os) }}
           version: latest
       - name: Setup sccache env variables
+        if: ${{ secrets.SCCACHE_AWS_SECRET != '' }}
         run: |
           echo "CC=$(which cc)" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=$HOME/.cargo/bin/sccache" >> $GITHUB_ENV

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -70,10 +70,10 @@ on:
     secrets:
       TOOL_CACHE_SECRET_KEY:
         description: "AWS secret key to access our Rust tool cache S3 bucket."
-        required: true
+        required: false
       SCCACHE_AWS_SECRET:
         description: "AWS secret key to access our sccache S3 bucket."
-        required: true
+        required: false
 
 jobs:
   # Assigns some variables, because GHA doesn't expand variables in inputs.*.default.
@@ -121,7 +121,8 @@ jobs:
           toolchain: ${{ matrix.rust_version }}
           targets: ${{ matrix.rust_target }}
       - name: Install sccache
-        uses: IronCoreLabs/rust-install@v0.1.0
+        if: ${{ secrets.SCCACHE_AWS_SECRET != '' }}
+        uses: IronCoreLabs/rust-install@v0.1.2
         with:
           crate: sccache
           accesskey: AKIAU2WBY6VDTC563V7G
@@ -129,6 +130,7 @@ jobs:
           os: buildjet-2vcpu-ubuntu-2204
           version: latest
       - name: Setup sccache env variables
+        if: ${{ secrets.SCCACHE_AWS_SECRET != '' }}
         run: |
           echo "CC=$(which cc)" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=$HOME/.cargo/bin/sccache" >> $GITHUB_ENV
@@ -171,7 +173,8 @@ jobs:
           sudo apt install ${{ inputs.additional_system_deps }}
       - uses: IronCoreLabs/rust-toolchain@v1
       - name: Install sccache
-        uses: IronCoreLabs/rust-install@v0.1.0
+        if: ${{ secrets.SCCACHE_AWS_SECRET != '' }}
+        uses: IronCoreLabs/rust-install@v0.1.2
         with:
           crate: sccache
           accesskey: AKIAU2WBY6VDTC563V7G
@@ -179,6 +182,7 @@ jobs:
           os: buildjet-2vcpu-ubuntu-2204
           version: latest
       - name: Setup sccache env variables
+        if: secrets.SCCACHE_AWS_SECRET != ''
         run: |
           echo "CC=$(which cc)" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=$HOME/.cargo/bin/sccache" >> $GITHUB_ENV
@@ -231,7 +235,7 @@ jobs:
       - run: ${{inputs.cargo_command_env_vars}} cargo fmt --all -- --check
         working-directory: ${{ needs.vars.outputs.rust_root }}
       - name: Install cargo-sort
-        uses: IronCoreLabs/rust-install@v0.1.0
+        uses: IronCoreLabs/rust-install@v0.1.2
         with:
           crate: cargo-sort
           accesskey: AKIAU2WBY6VDTC563V7G

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -94,6 +94,9 @@ jobs:
   cargo-test:
     runs-on: buildjet-2vcpu-ubuntu-2204
     needs: vars
+    env:
+      SCCACHE_AWS_SECRET: ${{ secrets.SCCACHE_AWS_SECRET }}
+      TOOL_CACHE_SECRET_KEY: ${{ secrets.TOOL_CACHE_SECRET_KEY }}
     strategy:
       matrix:
         rust_version: "${{ fromJSON(inputs.test_matrix_rust_version) }}"
@@ -121,7 +124,7 @@ jobs:
           toolchain: ${{ matrix.rust_version }}
           targets: ${{ matrix.rust_target }}
       - name: Install sccache
-        if: ${{ secrets.SCCACHE_AWS_SECRET != '' }}
+        if: env.SCCACHE_AWS_SECRET != ''
         uses: IronCoreLabs/rust-install@v0.1.2
         with:
           crate: sccache
@@ -130,12 +133,12 @@ jobs:
           os: buildjet-2vcpu-ubuntu-2204
           version: latest
       - name: Setup sccache env variables
-        if: ${{ secrets.SCCACHE_AWS_SECRET != '' }}
+        if: env.SCCACHE_AWS_SECRET != ''
         run: |
           echo "CC=$(which cc)" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=$HOME/.cargo/bin/sccache" >> $GITHUB_ENV
           echo "AWS_ACCESS_KEY_ID=AKIAU2WBY6VDVHUO5WSN" >> $GITHUB_ENV
-          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.SCCACHE_AWS_SECRET }}" >> $GITHUB_ENV
+          echo "AWS_SECRET_ACCESS_KEY=${{ env.SCCACHE_AWS_SECRET }}" >> $GITHUB_ENV
           echo "SCCACHE_BUCKET=sccache-rust" >> $GITHUB_ENV
           echo "SCCACHE_S3_USE_SSL=true" >> $GITHUB_ENV
           echo "SCCACHE_REGION=us-west-2" >> $GITHUB_ENV
@@ -151,11 +154,15 @@ jobs:
         if: ${{ !matrix.build_only }}
         working-directory: ${{ needs.vars.outputs.rust_root }}
       - name: Print sccache stats
+        if: env.SCCACHE_AWS_SECRET != ''
         run: sccache -s
 
   coverage:
     runs-on: buildjet-2vcpu-ubuntu-2204
     needs: vars
+    env:
+      SCCACHE_AWS_SECRET: ${{ secrets.SCCACHE_AWS_SECRET }}
+      TOOL_CACHE_SECRET_KEY: ${{ secrets.TOOL_CACHE_SECRET_KEY }}
     if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
     steps:
       - name: Configure git ssh access
@@ -173,16 +180,16 @@ jobs:
           sudo apt install ${{ inputs.additional_system_deps }}
       - uses: IronCoreLabs/rust-toolchain@v1
       - name: Install sccache
-        if: ${{ secrets.SCCACHE_AWS_SECRET != '' }}
+        if: env.SCCACHE_AWS_SECRET != ''
         uses: IronCoreLabs/rust-install@v0.1.2
         with:
           crate: sccache
           accesskey: AKIAU2WBY6VDTC563V7G
-          secretkey: ${{ secrets.TOOL_CACHE_SECRET_KEY }}
+          secretkey: ${{ env.TOOL_CACHE_SECRET_KEY }}
           os: buildjet-2vcpu-ubuntu-2204
           version: latest
       - name: Setup sccache env variables
-        if: secrets.SCCACHE_AWS_SECRET != ''
+        if: env.SCCACHE_AWS_SECRET != ''
         run: |
           echo "CC=$(which cc)" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=$HOME/.cargo/bin/sccache" >> $GITHUB_ENV

--- a/.github/workflows/rust-daily.yaml
+++ b/.github/workflows/rust-daily.yaml
@@ -34,10 +34,10 @@ on:
     secrets:
       TOOL_CACHE_SECRET_KEY:
         description: "AWS secret key to access our Rust tool cache S3 bucket."
-        required: true
+        required: false
       SCCACHE_AWS_SECRET:
         description: "AWS secret key to access our sccache S3 bucket."
-        required: true
+        required: false
 
 jobs:
   # Assigns some variables, because GHA doesn't expand variables in inputs.*.default.
@@ -58,6 +58,9 @@ jobs:
   cargo-check:
     runs-on: buildjet-2vcpu-ubuntu-2204
     needs: vars
+    env:
+      SCCACHE_AWS_SECRET: ${{ secrets.SCCACHE_AWS_SECRET }}
+      TOOL_CACHE_SECRET_KEY: ${{ secrets.TOOL_CACHE_SECRET_KEY }}
     defaults:
       run:
         working-directory: ${{ needs.vars.outputs.rust_root }}
@@ -85,19 +88,21 @@ jobs:
           toolchain: ${{ matrix.rust_version }}
           targets: ${{ matrix.rust_target }}
       - name: Install sccache
+        if: env.SCCACHE_AWS_SECRET != ''
         uses: IronCoreLabs/rust-install@v0.1.2
         with:
           crate: sccache
           accesskey: AKIAU2WBY6VDTC563V7G
-          secretkey: ${{ secrets.TOOL_CACHE_SECRET_KEY }}
+          secretkey: ${{ env.TOOL_CACHE_SECRET_KEY }}
           os: buildjet-2vcpu-ubuntu-2204
           version: latest
       - name: Setup sccache env variables
+        if: env.SCCACHE_AWS_SECRET != ''
         run: |
           echo "CC=$(which cc)" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=$HOME/.cargo/bin/sccache" >> $GITHUB_ENV
           echo "AWS_ACCESS_KEY_ID=AKIAU2WBY6VDVHUO5WSN" >> $GITHUB_ENV
-          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.SCCACHE_AWS_SECRET }}" >> $GITHUB_ENV
+          echo "AWS_SECRET_ACCESS_KEY=${{ env.SCCACHE_AWS_SECRET }}" >> $GITHUB_ENV
           echo "SCCACHE_BUCKET=sccache-rust" >> $GITHUB_ENV
           echo "SCCACHE_S3_USE_SSL=true" >> $GITHUB_ENV
           echo "SCCACHE_REGION=us-west-2" >> $GITHUB_ENV
@@ -109,4 +114,5 @@ jobs:
       - if: ${{ matrix.rust_target != '' }}
         run: cargo check --target=${{ matrix.rust_target }} --all-features
       - name: Print sccache stats
+        if: env.SCCACHE_AWS_SECRET != ''
         run: sccache -s

--- a/.github/workflows/rust-daily.yaml
+++ b/.github/workflows/rust-daily.yaml
@@ -85,7 +85,7 @@ jobs:
           toolchain: ${{ matrix.rust_version }}
           targets: ${{ matrix.rust_target }}
       - name: Install sccache
-        uses: IronCoreLabs/rust-install@v0.1.0
+        uses: IronCoreLabs/rust-install@v0.1.2
         with:
           crate: sccache
           accesskey: AKIAU2WBY6VDTC563V7G


### PR DESCRIPTION
Made secrets optional on Rust CI jobs so the workflows can be run on forks. 
As mentioned [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets), checking if the secrets are optional required us to locally scope the secrets to the job's env.