### PR TITLE
Add an optional PR check to Bump Version

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -77,6 +77,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       skip: ${{ steps.skip.outputs.skip }}
+    if: github.event_name != 'pull_request'
     steps:
       - name: Maybe skip
         id: skip
@@ -88,10 +89,29 @@ jobs:
             fi
           fi
 
+  check-versions:
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout own repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.WORKFLOW_PAT }}
+          path: self
+      - name: Checkout workflows repo
+        uses: actions/checkout@v4
+        with:
+          repository: IronCoreLabs/workflows
+          ref: ${{ inputs.workflows_repo_ref }}
+          token: ${{ secrets.WORKFLOW_PAT }}
+          path: workflows
+      - run: ../workflows/.github/bump-version.get.sh
+        working-directory: self
+
   bump:
     needs: skip
     runs-on: ubuntu-22.04
-    if: ${{ !needs.skip.outputs.skip }}
+    if: ${{ !needs.skip.outputs.skip && github.event_name != 'pull_request'}}
     steps:
       - name: Checkout own repo
         uses: actions/checkout@v4

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -105,7 +105,8 @@ jobs:
           ref: ${{ inputs.workflows_repo_ref }}
           token: ${{ secrets.WORKFLOW_PAT }}
           path: workflows
-      - run: ../workflows/.github/bump-version.get.sh
+      - name: Check all version numbers match
+        run: ../workflows/.github/bump-version.get.sh
         working-directory: self
 
   bump:


### PR DESCRIPTION
If you trigger Bump Version with a `pull_request` event, it will now do a quick check to make sure all version numbers line up in the repo. This will catch issues with Bump Version that previously wouldn't be caught until after merging.

The existing jobs of Bump Version now have `if: github.event_name != 'pull_request'` to make sure we don't accidentally actually bump on the PR.