### PR TITLE
Match the first version encountered in Cargo.toml

### DIFF
--- a/.github/bump-version.set.sh
+++ b/.github/bump-version.set.sh
@@ -44,7 +44,7 @@ for FILE in ${VERSFILES} ; do
         ;;
 
     Cargo.toml)
-        sed 's/^version = ".*"$/version = "'"${NEWVERS}"'"/' "${FILE}" > "${FILE}.tmp"
+        sed '0,/version/s/^version = ".*"$/version = "'"${NEWVERS}"'"/' "${FILE}" > "${FILE}.tmp"
         mv "${FILE}.tmp" "${FILE}"
 
         # If there's a Cargo.lock, update it also.


### PR DESCRIPTION
Won't increment other top level version lines (for dependencies etc).

Testable locally by running `bump-version.set.sh 1.0.0` against the test project to confirm current behavior. Then re-check out and manually edit `Cargo.toml` to have another `version = "3.0.0"` in it at the top level. Run it again, and see that it still only changes the first value to `1.0.0`.