### PR TITLE
Add --all-targets to rust-daily check

### DIFF
--- a/.github/workflows/rust-daily.yaml
+++ b/.github/workflows/rust-daily.yaml
@@ -110,9 +110,9 @@ jobs:
         with:
           cache-provider: buildjet
       - if: ${{ matrix.rust_target == '' }}
-        run: cargo check --all-features
+        run: cargo check --all-features --all-targets
       - if: ${{ matrix.rust_target != '' }}
-        run: cargo check --target=${{ matrix.rust_target }} --all-features
+        run: cargo check --target=${{ matrix.rust_target }} --all-features --all-targets
       - name: Print sccache stats
         if: env.SCCACHE_AWS_SECRET != ''
         run: sccache -s


### PR DESCRIPTION
This is a breaking change so will bump to rust-daily-v1

This will make the check cover everything, fixing it missing ironcore-alloy test failure in the integration_tests feature flag in tests