### PR TITLE
We can use coursier cache again

### DIFF
--- a/.github/workflows/scala-ci.yaml
+++ b/.github/workflows/scala-ci.yaml
@@ -54,12 +54,8 @@ jobs:
         run: |
           sudo apt update
           sudo apt install ${{ inputs.additional_system_deps }}
-      # This is broken and should be fixed by https://github.com/coursier/cache-action/pull/675.
-      # - name: Restore caches
-      #   uses: coursier/cache-action@v6
-      # This should be removed as well when above is fixed
-      - name: Delete Coursier and Ivy2 caches
-        run: rm -rf ~/.cache/coursier ~/.ivy2/cache
+      - name: Restore caches
+        uses: coursier/cache-action@v6
       - name: Setup Scala
         uses: coursier/setup-action@v1
         with:


### PR DESCRIPTION
https://github.com/coursier/cache-action/issues/666#issuecomment-2836427664 says that they fixed the issue. 