### PR TITLE
Change sccache credentials in several workflows

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -251,7 +251,7 @@ jobs:
         if: inputs.build_command == ''
         run: |
           docker build \
-          --build-arg AWS_ACCESS_KEY_ID=${{ vars.SCCACHE_AWS_ACCESS_KEY_ID }}
+          --build-arg AWS_ACCESS_KEY_ID=${{ vars.SCCACHE_AWS_ACCESS_KEY_ID }} \
           --build-arg AWS_SECRET_ACCESS_KEY=${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }} \
           ${{ inputs.configure_git_ssh && '--ssh=default="${HOME}/.ssh/id_ed25519"' || '' }} \
           ${{ inputs.docker_build_target }} \

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -251,7 +251,8 @@ jobs:
         if: inputs.build_command == ''
         run: |
           docker build \
-          --build-arg AWS_SECRET_ACCESS_KEY=${{ secrets.SCCACHE_AWS_SECRET }} \
+          --build-arg AWS_ACCESS_KEY_ID=${{ vars.SCCACHE_AWS_ACCESS_KEY_ID }}
+          --build-arg AWS_SECRET_ACCESS_KEY=${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }} \
           ${{ inputs.configure_git_ssh && '--ssh=default="${HOME}/.ssh/id_ed25519"' || '' }} \
           ${{ inputs.docker_build_target }} \
           --pull -t ${{ steps.name.outputs.canonical }}-${{ steps.arch.outputs.arch }} .

--- a/.github/workflows/rust-artifact.yaml
+++ b/.github/workflows/rust-artifact.yaml
@@ -58,7 +58,7 @@ jobs:
   cargo-artifact:
     runs-on: ${{ matrix.os }}
     env:
-      SCCACHE_AWS_SECRET: ${{ secrets.SCCACHE_AWS_SECRET }}
+      SCCACHE_AWS_SECRET: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
       TOOL_CACHE_SECRET_KEY: ${{ secrets.TOOL_CACHE_SECRET_KEY }}
     strategy:
       fail-fast: false
@@ -99,7 +99,7 @@ jobs:
         run: |
           echo "CC=$(which cc)" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=$HOME/.cargo/bin/sccache" >> $GITHUB_ENV
-          echo "AWS_ACCESS_KEY_ID=AKIAU2WBY6VDVHUO5WSN" >> $GITHUB_ENV
+          echo "AWS_ACCESS_KEY_ID=${{ vars.SCCACHE_AWS_ACCESS_KEY_ID }}" >> $GITHUB_ENV
           echo "AWS_SECRET_ACCESS_KEY=${{ env.SCCACHE_AWS_SECRET }}" >> $GITHUB_ENV
           echo "SCCACHE_BUCKET=sccache-rust" >> $GITHUB_ENV
           echo "SCCACHE_S3_USE_SSL=true" >> $GITHUB_ENV

--- a/.github/workflows/rust-artifact.yaml
+++ b/.github/workflows/rust-artifact.yaml
@@ -50,9 +50,6 @@ on:
       TOOL_CACHE_SECRET_KEY:
         description: "AWS secret key to access our Rust tool cache S3 bucket."
         required: false
-      SCCACHE_AWS_SECRET:
-        description: "AWS secret key to access our sccache S3 bucket."
-        required: false
 
 jobs:
   cargo-artifact:

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: vars
     env:
-      SCCACHE_AWS_SECRET: ${{ secrets.SCCACHE_AWS_SECRET }}
+      SCCACHE_AWS_SECRET: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
       TOOL_CACHE_SECRET_KEY: ${{ secrets.TOOL_CACHE_SECRET_KEY }}
     strategy:
       matrix:
@@ -138,7 +138,7 @@ jobs:
         run: |
           echo "CC=$(which cc)" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=$HOME/.cargo/bin/sccache" >> $GITHUB_ENV
-          echo "AWS_ACCESS_KEY_ID=AKIAU2WBY6VDVHUO5WSN" >> $GITHUB_ENV
+          echo "AWS_ACCESS_KEY_ID=${{ vars.SCCACHE_AWS_ACCESS_KEY_ID }}" >> $GITHUB_ENV
           echo "AWS_SECRET_ACCESS_KEY=${{ env.SCCACHE_AWS_SECRET }}" >> $GITHUB_ENV
           echo "SCCACHE_BUCKET=sccache-rust" >> $GITHUB_ENV
           echo "SCCACHE_S3_USE_SSL=true" >> $GITHUB_ENV
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: vars
     env:
-      SCCACHE_AWS_SECRET: ${{ secrets.SCCACHE_AWS_SECRET }}
+      SCCACHE_AWS_SECRET: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
       TOOL_CACHE_SECRET_KEY: ${{ secrets.TOOL_CACHE_SECRET_KEY }}
     if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
     steps:
@@ -194,8 +194,8 @@ jobs:
         run: |
           echo "CC=$(which cc)" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=$HOME/.cargo/bin/sccache" >> $GITHUB_ENV
-          echo "AWS_ACCESS_KEY_ID=AKIAU2WBY6VDVHUO5WSN" >> $GITHUB_ENV
-          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.SCCACHE_AWS_SECRET }}" >> $GITHUB_ENV
+          echo "AWS_ACCESS_KEY_ID=${{ vars.SCCACHE_AWS_ACCESS_KEY_ID }}" >> $GITHUB_ENV
+          echo "AWS_SECRET_ACCESS_KEY=${{ env.SCCACHE_AWS_SECRET }}" >> $GITHUB_ENV
           echo "SCCACHE_BUCKET=sccache-rust" >> $GITHUB_ENV
           echo "SCCACHE_S3_USE_SSL=true" >> $GITHUB_ENV
           echo "SCCACHE_REGION=us-west-2" >> $GITHUB_ENV

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -71,9 +71,6 @@ on:
       TOOL_CACHE_SECRET_KEY:
         description: "AWS secret key to access our Rust tool cache S3 bucket."
         required: false
-      SCCACHE_AWS_SECRET:
-        description: "AWS secret key to access our sccache S3 bucket."
-        required: false
 
 jobs:
   # Assigns some variables, because GHA doesn't expand variables in inputs.*.default.

--- a/.github/workflows/rust-daily.yaml
+++ b/.github/workflows/rust-daily.yaml
@@ -59,7 +59,7 @@ jobs:
     runs-on: buildjet-2vcpu-ubuntu-2204
     needs: vars
     env:
-      SCCACHE_AWS_SECRET: ${{ secrets.SCCACHE_AWS_SECRET }}
+      SCCACHE_AWS_SECRET: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
       TOOL_CACHE_SECRET_KEY: ${{ secrets.TOOL_CACHE_SECRET_KEY }}
     defaults:
       run:
@@ -101,7 +101,7 @@ jobs:
         run: |
           echo "CC=$(which cc)" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=$HOME/.cargo/bin/sccache" >> $GITHUB_ENV
-          echo "AWS_ACCESS_KEY_ID=AKIAU2WBY6VDVHUO5WSN" >> $GITHUB_ENV
+          echo "AWS_ACCESS_KEY_ID=${{ vars.SCCACHE_AWS_ACCESS_KEY_ID }}" >> $GITHUB_ENV
           echo "AWS_SECRET_ACCESS_KEY=${{ env.SCCACHE_AWS_SECRET }}" >> $GITHUB_ENV
           echo "SCCACHE_BUCKET=sccache-rust" >> $GITHUB_ENV
           echo "SCCACHE_S3_USE_SSL=true" >> $GITHUB_ENV

--- a/.github/workflows/rust-daily.yaml
+++ b/.github/workflows/rust-daily.yaml
@@ -35,9 +35,6 @@ on:
       TOOL_CACHE_SECRET_KEY:
         description: "AWS secret key to access our Rust tool cache S3 bucket."
         required: false
-      SCCACHE_AWS_SECRET:
-        description: "AWS secret key to access our sccache S3 bucket."
-        required: false
 
 jobs:
   # Assigns some variables, because GHA doesn't expand variables in inputs.*.default.


### PR DESCRIPTION
- Moves the access key to a var instead of hard-coded
- Switches the secret key to the new organization secret
- Removes the optional declaration of the secrets from the top of the workflows