### PR TITLE
This adds a reusable workflow for sql smelter

### DIFF
--- a/.github/workflows/sql-smelter.yaml
+++ b/.github/workflows/sql-smelter.yaml
@@ -1,0 +1,190 @@
+name: SQL Smelter Integration Workflow
+
+on:
+  workflow_call:
+    outputs:
+      selected_branch:
+        description: "The branch that was selected for checkout"
+        value: ${{ jobs.determine-branch.outputs.selected_branch }}
+    secrets:
+      token:
+        description: "GitHub token with necessary permissions"
+        required: true
+
+permissions:
+  pull-requests: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  add-initial-comment:
+    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add initial comment
+        id: add-comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const body = "Using the `main` branch of `sql-smelter` for tests on this PR. If you would like to change that, comment with `sql-smelter/<branch_name>` and that will be used instead.";
+
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+
+            const existingComment = comments.find(comment =>
+              comment.body.includes('Using the `main` branch of `sql-smelter`') &&
+              comment.body.includes("If you'd like to change that")
+            );
+
+            if (!existingComment) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body
+              });
+              console.log(`Added initial comment to PR #${issue_number}`);
+            } else {
+              console.log(`Comment already exists on PR #${issue_number}, skipping`);
+            }
+
+  detect-branch-comment:
+    if: github.event_name == 'issue_comment' && github.event.action == 'created'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect branch comment
+        id: detect-comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comment_id = context.payload.comment.id;
+            const comment_body = context.payload.comment.body;
+
+            const branchPattern = /sql[-\s]?smelter\s*\/\s*([a-zA-Z0-9_\-\.\/]+)/i;
+            const match = comment_body.match(branchPattern);
+
+            if (match) {
+              const branchName = match[1];
+              console.log(`Detected branch specification: sql-smelter/${branchName}`);
+
+              await github.rest.reactions.createForIssueComment({
+                owner,
+                repo,
+                comment_id,
+                content: '+1'
+              });
+
+              const markerComment = `<!-- SQL_SMELTER_BRANCH_SELECTION -->\nBranch selected for PR #${issue_number}: sql-smelter/${branchName}`;
+
+              const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+              const existingMarkerComment = comments.find(comment =>
+                comment.body.includes('<!-- SQL_SMELTER_BRANCH_SELECTION -->')
+              );
+
+              if (existingMarkerComment) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existingMarkerComment.id,
+                  body: markerComment
+                });
+                console.log(`Updated branch selection marker comment #${existingMarkerComment.id}`);
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body: markerComment
+                });
+                console.log(`Created branch selection marker comment`);
+              }
+            } else {
+              console.log('Comment does not contain a branch specification, ignoring');
+            }
+
+  determine-branch:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      selected_branch: ${{ steps.get-branch.outputs.branch }}
+    steps:
+      - name: Get branch to checkout
+        id: get-branch
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            let selectedBranch = 'main';
+
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const markerComment = comments.find(comment =>
+              comment.body.includes('<!-- SQL_SMELTER_BRANCH_SELECTION -->')
+            );
+
+            if (markerComment) {
+              const match = markerComment.body.match(/sql-smelter\/([a-zA-Z0-9_\-\.\/]+)/);
+              if (match) {
+                selectedBranch = match[1];
+                console.log(`Found branch selection in marker comment: ${selectedBranch}`);
+              }
+            }
+
+            core.setOutput('branch', selectedBranch);
+            console.log(`Selected branch for checkout: ${selectedBranch}`);
+
+  checkout-branch:
+    needs: determine-branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v4
+
+      - name: Checkout sql-smelter repository
+        id: checkout-sql-smelter
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          repository: IronCoreLabs/sql-smelter
+          ref: ${{ needs.determine-branch.outputs.selected_branch }}
+          path: "sql-smelter"
+          token: ${{ secrets.token }}
+
+      - name: Fallback to default branch on error
+        if: steps.checkout-sql-smelter.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          repository: IronCoreLabs/sql-smelter
+          ref: main
+          path: "sql-smelter"
+          token: ${{ secrets.token }}
+
+      - name: Notify about fallback
+        if: steps.checkout-sql-smelter.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: `⚠️ Failed to checkout branch \`sql-smelter/${{ needs.determine-branch.outputs.selected_branch }}\`. Falling back to \`sql-smelter/main\`.`
+            });
+
+      - name: Display checkout information
+        run: |
+          echo "Checked out sql-smelter repository at branch: ${{ needs.determine-branch.outputs.selected_branch }}"

--- a/.github/workflows/sql-smelter.yaml
+++ b/.github/workflows/sql-smelter.yaml
@@ -33,13 +33,17 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
-            const body = "Using the `main` branch of `sql-smelter` for tests on this PR. If you would like to change that, comment with `sql-smelter/<branch_name>` and that will be used instead.";
 
+            // Create the unified comment with the marker
+            const body = `<!-- SQL_SMELTER_BRANCH_SELECTION -->
+            Branch selected for PR #${issue_number}: sql-smelter/main
+
+            If you want to change the branch, comment on this PR with \`sql-smelter/<branch-name>\`.`;
+
+            // Check if a comment already exists to avoid duplicates
             const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
-
             const existingComment = comments.find(comment =>
-              comment.body.includes('Using the `main` branch of `sql-smelter`') &&
-              comment.body.includes("If you'd like to change that")
+              comment.body.includes('<!-- SQL_SMELTER_BRANCH_SELECTION -->')
             );
 
             if (!existingComment) {
@@ -49,9 +53,9 @@ jobs:
                 issue_number,
                 body
               });
-              console.log(`Added initial comment to PR #${issue_number}`);
+              console.log(`Added initial branch selection comment to PR #${issue_number}`);
             } else {
-              console.log(`Comment already exists on PR #${issue_number}, skipping`);
+              console.log(`Branch selection comment already exists on PR #${issue_number}, skipping`);
             }
 
   detect-branch-comment:
@@ -68,7 +72,15 @@ jobs:
             const issue_number = context.issue.number;
             const comment_id = context.payload.comment.id;
             const comment_body = context.payload.comment.body;
+            const comment_user = context.payload.comment.user.login;
 
+            // Skip if the comment is from github-actions bot or contains our marker
+            if (comment_body.includes('<!-- SQL_SMELTER_BRANCH_SELECTION -->')) {
+              console.log('Comment is from GitHub Actions bot or contains our marker, ignoring');
+              return;
+            }
+
+            // More flexible pattern to handle variations
             const branchPattern = /sql[-\s]?smelter\s*\/\s*([a-zA-Z0-9_\-\.\/]+)/i;
             const match = comment_body.match(branchPattern);
 
@@ -76,6 +88,7 @@ jobs:
               const branchName = match[1];
               console.log(`Detected branch specification: sql-smelter/${branchName}`);
 
+              // Add thumbs up reaction to the comment
               await github.rest.reactions.createForIssueComment({
                 owner,
                 repo,
@@ -83,29 +96,36 @@ jobs:
                 content: '+1'
               });
 
-              const markerComment = `<!-- SQL_SMELTER_BRANCH_SELECTION -->\nBranch selected for PR #${issue_number}: sql-smelter/${branchName}`;
+              // Create or update the unified comment
+              const updatedBody = `<!-- SQL_SMELTER_BRANCH_SELECTION -->
+              Branch selected for PR #${issue_number}: sql-smelter/${branchName}
 
+              If you want to change the branch, comment on this PR with \`sql-smelter/<branch-name>\`.`;
+
+              // Find the existing comment with our marker
               const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
-              const existingMarkerComment = comments.find(comment =>
+              const existingComment = comments.find(comment =>
                 comment.body.includes('<!-- SQL_SMELTER_BRANCH_SELECTION -->')
               );
 
-              if (existingMarkerComment) {
+              if (existingComment) {
+                // Update the existing comment
                 await github.rest.issues.updateComment({
                   owner,
                   repo,
-                  comment_id: existingMarkerComment.id,
-                  body: markerComment
+                  comment_id: existingComment.id,
+                  body: updatedBody
                 });
-                console.log(`Updated branch selection marker comment #${existingMarkerComment.id}`);
+                console.log(`Updated branch selection comment #${existingComment.id}`);
               } else {
+                // Create a new comment if somehow it doesn't exist
                 await github.rest.issues.createComment({
                   owner,
                   repo,
                   issue_number,
-                  body: markerComment
+                  body: updatedBody
                 });
-                console.log(`Created branch selection marker comment`);
+                console.log(`Created branch selection comment`);
               }
             } else {
               console.log('Comment does not contain a branch specification, ignoring');
@@ -127,16 +147,18 @@ jobs:
             const issue_number = context.issue.number;
             let selectedBranch = 'main';
 
+            // Find the comment with our marker
             const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
             const markerComment = comments.find(comment =>
               comment.body.includes('<!-- SQL_SMELTER_BRANCH_SELECTION -->')
             );
 
             if (markerComment) {
+              // Extract the branch name from the marker comment
               const match = markerComment.body.match(/sql-smelter\/([a-zA-Z0-9_\-\.\/]+)/);
               if (match) {
                 selectedBranch = match[1];
-                console.log(`Found branch selection in marker comment: ${selectedBranch}`);
+                console.log(`Found branch selection in comment: ${selectedBranch}`);
               }
             }
 
@@ -160,16 +182,7 @@ jobs:
           path: "sql-smelter"
           token: ${{ secrets.token }}
 
-      - name: Fallback to default branch on error
-        if: steps.checkout-sql-smelter.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          repository: IronCoreLabs/sql-smelter
-          ref: main
-          path: "sql-smelter"
-          token: ${{ secrets.token }}
-
-      - name: Notify about fallback
+      - name: Notify about checkout failure
         if: steps.checkout-sql-smelter.outcome == 'failure'
         uses: actions/github-script@v7
         with:
@@ -178,13 +191,51 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
 
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number,
-              body: `⚠️ Failed to checkout branch \`sql-smelter/${{ needs.determine-branch.outputs.selected_branch }}\`. Falling back to \`sql-smelter/main\`.`
-            });
+            // Find the existing comment with our marker
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existingComment = comments.find(comment =>
+              comment.body.includes('<!-- SQL_SMELTER_BRANCH_SELECTION -->')
+            );
+
+            if (existingComment) {
+              // Get the current content and add the failure message
+              let updatedBody = existingComment.body;
+
+              // Check if there's already a failure message
+              if (!updatedBody.includes('⚠️ Failed to checkout branch')) {
+                updatedBody += `\n\n⚠️ Failed to checkout branch \`sql-smelter/${{ needs.determine-branch.outputs.selected_branch }}\`.`;
+              }
+
+              // Update the comment
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body: updatedBody
+              });
+              console.log(`Updated comment with checkout failure notification`);
+            } else {
+              // If for some reason the comment doesn't exist, create it
+              const body = `<!-- SQL_SMELTER_BRANCH_SELECTION -->
+                Branch selected for PR #${issue_number}: sql-smelter/${{ needs.determine-branch.outputs.selected_branch }}
+
+                If you want to change the branch, comment on this PR with \`sql-smelter/<branch-name>\`.
+
+                ⚠️ Failed to checkout branch \`sql-smelter/${{ needs.determine-branch.outputs.selected_branch }}\`.`;
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body
+              });
+              console.log(`Created comment with checkout failure notification`);
+            }
+
+            // Exit with error to indicate the workflow should fail
+            core.setFailed(`Failed to checkout branch sql-smelter/${{ needs.determine-branch.outputs.selected_branch }}`);
 
       - name: Display checkout information
+        if: steps.checkout-sql-smelter.outcome == 'success'
         run: |
           echo "Checked out sql-smelter repository at branch: ${{ needs.determine-branch.outputs.selected_branch }}"

--- a/.github/workflows/sql-smelter.yaml
+++ b/.github/workflows/sql-smelter.yaml
@@ -59,6 +59,7 @@ jobs:
             }
 
   detect-branch-comment:
+    if: github.event_name == 'issue_comment' && github.event.action == 'created'
     runs-on: ubuntu-latest
     steps:
       - name: Detect branch comment
@@ -67,23 +68,11 @@ jobs:
         with:
           github-token: ${{ secrets.token }}
           script: |
-
-            if(!context){
-              console.log(`Skipping: not an 'issue_comment' creation.`);
-              return;
-            }
-            const { eventName, payload, repo } = context;
-
-            if (eventName !== 'issue_comment' || payload.action !== 'created') {
-              console.log(`Skipping: not an 'issue_comment' creation (got ${eventName} / ${payload.action})`);
-              return;
-            }
-
-            const { owner } = repo;
-            const issue_number = payload.issue.number;
-            const comment_id = payload.comment.id;
-            const comment_body = payload.comment.body;
-            const comment_user = payload.comment.user.login;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comment_id = context.payload.comment.id;
+            const comment_body = context.payload.comment.body;
+            const comment_user = context.payload.comment.user.login;
 
             if (comment_body.includes('<!-- SQL_SMELTER_BRANCH_SELECTION -->')) {
               console.log('Comment is from GitHub Actions bot or contains our marker, ignoring');
@@ -94,13 +83,12 @@ jobs:
             const match = comment_body.match(branchPattern);
 
             if (match) {
-              core.setOutput('should_cancel', 'false');
               const branchName = match[1];
               console.log(`Detected branch specification: sql-smelter/${branchName}`);
 
               await github.rest.reactions.createForIssueComment({
                 owner,
-                repo: repo.repo,
+                repo,
                 comment_id,
                 content: '+1'
               });
@@ -108,11 +96,13 @@ jobs:
               const updatedBody = `<!-- SQL_SMELTER_BRANCH_SELECTION -->
               Branch selected for PR #${issue_number}: sql-smelter/${branchName}
 
-              If you want to change the branch, comment on this PR with \`sql-smelter/<branch-name>\`.`;
+              If you want to change the branch, comment on this PR with \`sql-smelter/<branch-name>\`.
+
+              ⚠️ Pull Request checks have not been run using this updated branch.`;
 
               const { data: comments } = await github.rest.issues.listComments({
                 owner,
-                repo: repo.repo,
+                repo,
                 issue_number
               });
 
@@ -123,7 +113,7 @@ jobs:
               if (existingComment) {
                 await github.rest.issues.updateComment({
                   owner,
-                  repo: repo.repo,
+                  repo,
                   comment_id: existingComment.id,
                   body: updatedBody
                 });
@@ -131,24 +121,17 @@ jobs:
               } else {
                 await github.rest.issues.createComment({
                   owner,
-                  repo: repo.repo,
+                  repo,
                   issue_number,
                   body: updatedBody
                 });
                 console.log(`Created branch selection comment`);
               }
             } else {
-              core.setOutput('should_cancel', 'true');
               console.log('Comment does not contain a branch specification, ignoring');
             }
-      - name: Cancel workflow if no valid branch
-        if: steps.detect-comment.outputs.should_cancel == 'true'
-        uses: andymckay/cancel-action@0.5
-        with:
-          token: ${{ secrets.token }}
 
   determine-branch:
-    needs: detect-branch-comment
     runs-on: ubuntu-latest
     outputs:
       selected_branch: ${{ steps.get-branch.outputs.branch }}
@@ -197,6 +180,49 @@ jobs:
           ref: ${{ needs.determine-branch.outputs.selected_branch }}
           path: "sql-smelter"
           token: ${{ secrets.token }}
+      - name: Remove "checks not run" warning from comment
+        if: steps.checkout-sql-smelter.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existingComment = comments.find(comment =>
+              comment.body.includes('<!-- SQL_SMELTER_BRANCH_SELECTION -->')
+            );
+
+            if (!existingComment) {
+              console.log("No branch selection comment found to update.");
+              return;
+            }
+
+            let updatedBody = existingComment.body;
+
+            // Split into lines and filter out warning lines
+            const cleanedLines = updatedBody
+              .split('\n')
+              .filter(line =>
+                !line.includes('⚠️ Pull Request checks have not been run using this updated branch.') &&
+                !line.trimStart().startsWith('⚠️ Failed to checkout branch')
+              );
+
+            const cleanedBody = cleanedLines.join('\n').trim();
+
+            if (cleanedBody !== updatedBody.trim()) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body: cleanedBody
+              });
+
+              console.log("Removed warning lines from comment.");
+            } else {
+              console.log("No warning lines to remove.");
+            }
 
       - name: Notify about checkout failure
         if: steps.checkout-sql-smelter.outcome == 'failure'

--- a/.github/workflows/sql-smelter.yaml
+++ b/.github/workflows/sql-smelter.yaml
@@ -59,7 +59,6 @@ jobs:
             }
 
   detect-branch-comment:
-    if: github.event_name == 'issue_comment' && github.event.action == 'created'
     runs-on: ubuntu-latest
     steps:
       - name: Detect branch comment
@@ -68,19 +67,24 @@ jobs:
         with:
           github-token: ${{ secrets.token }}
           script: |
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const comment_id = context.payload.comment.id;
-            const comment_body = context.payload.comment.body;
-            const comment_user = context.payload.comment.user.login;
+            const { eventName, payload, repo } = github.context;
 
-            // Skip if the comment is from github-actions bot or contains our marker
+            if (eventName !== 'issue_comment' || payload.action !== 'created') {
+              console.log(`Skipping: not an 'issue_comment' creation (got ${eventName} / ${payload.action})`);
+              return;
+            }
+
+            const { owner } = repo;
+            const issue_number = payload.issue.number;
+            const comment_id = payload.comment.id;
+            const comment_body = payload.comment.body;
+            const comment_user = payload.comment.user.login;
+
             if (comment_body.includes('<!-- SQL_SMELTER_BRANCH_SELECTION -->')) {
               console.log('Comment is from GitHub Actions bot or contains our marker, ignoring');
               return;
             }
 
-            // More flexible pattern to handle variations
             const branchPattern = /sql[-\s]?smelter\s*\/\s*([a-zA-Z0-9_\-\.\/]+)/i;
             const match = comment_body.match(branchPattern);
 
@@ -88,40 +92,40 @@ jobs:
               const branchName = match[1];
               console.log(`Detected branch specification: sql-smelter/${branchName}`);
 
-              // Add thumbs up reaction to the comment
               await github.rest.reactions.createForIssueComment({
                 owner,
-                repo,
+                repo: repo.repo,
                 comment_id,
                 content: '+1'
               });
 
-              // Create or update the unified comment
               const updatedBody = `<!-- SQL_SMELTER_BRANCH_SELECTION -->
-              Branch selected for PR #${issue_number}: sql-smelter/${branchName}
+                Branch selected for PR #${issue_number}: sql-smelter/${branchName}
 
-              If you want to change the branch, comment on this PR with \`sql-smelter/<branch-name>\`.`;
+                If you want to change the branch, comment on this PR with \`sql-smelter/<branch-name>\`.`;
 
-              // Find the existing comment with our marker
-              const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo: repo.repo,
+                issue_number
+              });
+
               const existingComment = comments.find(comment =>
                 comment.body.includes('<!-- SQL_SMELTER_BRANCH_SELECTION -->')
               );
 
               if (existingComment) {
-                // Update the existing comment
                 await github.rest.issues.updateComment({
                   owner,
-                  repo,
+                  repo: repo.repo,
                   comment_id: existingComment.id,
                   body: updatedBody
                 });
                 console.log(`Updated branch selection comment #${existingComment.id}`);
               } else {
-                // Create a new comment if somehow it doesn't exist
                 await github.rest.issues.createComment({
                   owner,
-                  repo,
+                  repo: repo.repo,
                   issue_number,
                   body: updatedBody
                 });
@@ -132,6 +136,7 @@ jobs:
             }
 
   determine-branch:
+    needs: detect-branch-comment
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/sql-smelter.yaml
+++ b/.github/workflows/sql-smelter.yaml
@@ -67,6 +67,11 @@ jobs:
         with:
           github-token: ${{ secrets.token }}
           script: |
+
+            if(!github.context){
+              console.log(`Skipping: not an 'issue_comment' creation.`);
+              return;
+            }
             const { eventName, payload, repo } = github.context;
 
             if (eventName !== 'issue_comment' || payload.action !== 'created') {
@@ -137,7 +142,6 @@ jobs:
 
   determine-branch:
     needs: detect-branch-comment
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       selected_branch: ${{ steps.get-branch.outputs.branch }}

--- a/.github/workflows/sql-smelter.yaml
+++ b/.github/workflows/sql-smelter.yaml
@@ -144,6 +144,8 @@ jobs:
       - name: Cancel workflow if no valid branch
         if: steps.detect-comment.outputs.should_cancel == 'true'
         uses: andymckay/cancel-action@0.5
+        with:
+          token: ${{ secrets.token }}
 
   determine-branch:
     needs: detect-branch-comment

--- a/.github/workflows/sql-smelter.yaml
+++ b/.github/workflows/sql-smelter.yaml
@@ -94,6 +94,7 @@ jobs:
             const match = comment_body.match(branchPattern);
 
             if (match) {
+              core.setOutput('should_cancel', 'false');
               const branchName = match[1];
               console.log(`Detected branch specification: sql-smelter/${branchName}`);
 
@@ -105,9 +106,9 @@ jobs:
               });
 
               const updatedBody = `<!-- SQL_SMELTER_BRANCH_SELECTION -->
-                Branch selected for PR #${issue_number}: sql-smelter/${branchName}
+              Branch selected for PR #${issue_number}: sql-smelter/${branchName}
 
-                If you want to change the branch, comment on this PR with \`sql-smelter/<branch-name>\`.`;
+              If you want to change the branch, comment on this PR with \`sql-smelter/<branch-name>\`.`;
 
               const { data: comments } = await github.rest.issues.listComments({
                 owner,
@@ -137,8 +138,12 @@ jobs:
                 console.log(`Created branch selection comment`);
               }
             } else {
+              core.setOutput('should_cancel', 'true');
               console.log('Comment does not contain a branch specification, ignoring');
             }
+      - name: Cancel workflow if no valid branch
+        if: steps.detect-comment.outputs.should_cancel == 'true'
+        uses: andymckay/cancel-action@0.5
 
   determine-branch:
     needs: detect-branch-comment

--- a/.github/workflows/sql-smelter.yaml
+++ b/.github/workflows/sql-smelter.yaml
@@ -132,6 +132,7 @@ jobs:
             }
 
   determine-branch:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       selected_branch: ${{ steps.get-branch.outputs.branch }}

--- a/.github/workflows/sql-smelter.yaml
+++ b/.github/workflows/sql-smelter.yaml
@@ -68,11 +68,11 @@ jobs:
           github-token: ${{ secrets.token }}
           script: |
 
-            if(!github.context){
+            if(!context){
               console.log(`Skipping: not an 'issue_comment' creation.`);
               return;
             }
-            const { eventName, payload, repo } = github.context;
+            const { eventName, payload, repo } = context;
 
             if (eventName !== 'issue_comment' || payload.action !== 'created') {
               console.log(`Skipping: not an 'issue_comment' creation (got ${eventName} / ${payload.action})`);


### PR DESCRIPTION
This reusable workflow has 4 jobs:

`add-initial-comment` - This adds a comment to the pull request that we'll keep updating as the state we track for sql-smelter changes. It can run many times, but will not create another comment once one is created.
`detect-branch-comment` - This runs anytime a comment is created on the pull request. It looks for `sql-smelter/<branch-name> and will update which sql-smelter branch to use for the tests on that branch.
`determine-branch` - Using the comment added by `add-initial-comment` it will determine which branch to use.
`checkout-branch` - Tries to checkout the branch, updating the state of the initial comment with if it's successful or not.
