### PR TITLE
Switch Docker workflow to WIF

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -348,6 +348,10 @@ jobs:
         with:
           service_account: depot-ci@ironcore-dev-1.iam.gserviceaccount.com
           workload_identity_provider: projects/660542197445/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+      - name: Configure Docker
+        run: |
+          gcloud auth configure-docker --quiet
+          gcloud auth configure-docker us-docker.pkg.dev --quiet
       - name: Get canonical image name
         id: name
         run: echo "canonical=$(echo ${{ needs.image.outputs.images }} | sed 's/ .*//')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -235,14 +235,10 @@ jobs:
         with:
           keys: ${{ secrets.IRONHIDE_KEYS }}
           input: ${{ inputs.additional_decryption_files }}
-      - name: Configure gcloud
-        run: |
-          cat > .github/gcloud-auth.json <<EOF
-          ${{ secrets.GCLOUD_AUTH }}
-          EOF
-          gcloud auth activate-service-account --key-file .github/gcloud-auth.json
-          gcloud auth configure-docker --quiet
-          gcloud auth configure-docker us-docker.pkg.dev --quiet
+      - uses: "google-github-actions/auth@v3"
+        with:
+          service_account: depot-ci@ironcore-dev-1.iam.gserviceaccount.com
+          workload_identity_provider: projects/660542197445/locations/global/workloadIdentityPools/github-actions/providers/github-actions
       - name: Get canonical image name
         id: name
         run: |
@@ -338,14 +334,10 @@ jobs:
         with:
           # Either the workflow_dispatch ref, or the prerelease tag, whichever is set.
           ref: ${{ github.event.inputs.ref }}${{ github.event.release.tag_name }}
-      - name: Configure gcloud
-        run: |
-          cat > .github/gcloud-auth.json <<EOF
-          ${{ secrets.GCLOUD_AUTH }}
-          EOF
-          gcloud auth activate-service-account --key-file .github/gcloud-auth.json
-          gcloud auth configure-docker --quiet
-          gcloud auth configure-docker us-docker.pkg.dev --quiet
+      - uses: "google-github-actions/auth@v3"
+        with:
+          service_account: depot-ci@ironcore-dev-1.iam.gserviceaccount.com
+          workload_identity_provider: projects/660542197445/locations/global/workloadIdentityPools/github-actions/providers/github-actions
       - name: Get canonical image name
         id: name
         run: echo "canonical=$(echo ${{ needs.image.outputs.images }} | sed 's/ .*//')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -279,6 +279,8 @@ jobs:
         run: |
           docker save -o /tmp/docker.tar "${{ steps.name.outputs.canonical }}-${{ steps.arch.outputs.arch }}"
           clamscan /tmp/docker.tar
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v3
       - name: Push it!
         run: docker push "${{ steps.name.outputs.canonical }}-${{ steps.arch.outputs.arch }}"
       - name: Tag and push additional image

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -177,6 +177,8 @@ jobs:
   docker:
     needs: image
     runs-on: ${{ matrix.runs_on }}
+    permissions:
+      id-token: write
     env:
       DOCKER_BUILDKIT: 1
       MAVEN_IRONCORELABS_COM_AWS_ACCESS_KEY_ID: ${{ vars.MAVEN_IRONCORELABS_COM_AWS_ACCESS_KEY_ID }}
@@ -329,6 +331,8 @@ jobs:
   publish:
     needs: [docker, image]
     runs-on: ${{ inputs.other_jobs_runs_on }}
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -178,6 +178,7 @@ jobs:
     needs: image
     runs-on: ${{ matrix.runs_on }}
     permissions:
+      contents: read
       id-token: write
     env:
       DOCKER_BUILDKIT: 1
@@ -237,7 +238,7 @@ jobs:
         with:
           keys: ${{ secrets.IRONHIDE_KEYS }}
           input: ${{ inputs.additional_decryption_files }}
-      - uses: "google-github-actions/auth@v3"
+      - uses: google-github-actions/auth@v3
         with:
           service_account: depot-ci@ironcore-dev-1.iam.gserviceaccount.com
           workload_identity_provider: projects/660542197445/locations/global/workloadIdentityPools/github-actions/providers/github-actions
@@ -332,13 +333,14 @@ jobs:
     needs: [docker, image]
     runs-on: ${{ inputs.other_jobs_runs_on }}
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
           # Either the workflow_dispatch ref, or the prerelease tag, whichever is set.
           ref: ${{ github.event.inputs.ref }}${{ github.event.release.tag_name }}
-      - uses: "google-github-actions/auth@v3"
+      - uses: google-github-actions/auth@v3
         with:
           service_account: depot-ci@ironcore-dev-1.iam.gserviceaccount.com
           workload_identity_provider: projects/660542197445/locations/global/workloadIdentityPools/github-actions/providers/github-actions

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -242,6 +242,10 @@ jobs:
         with:
           service_account: depot-ci@ironcore-dev-1.iam.gserviceaccount.com
           workload_identity_provider: projects/660542197445/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+      - name: Configure Docker
+        run: |
+          gcloud auth configure-docker --quiet
+          gcloud auth configure-docker us-docker.pkg.dev --quiet
       - name: Get canonical image name
         id: name
         run: |
@@ -279,8 +283,6 @@ jobs:
         run: |
           docker save -o /tmp/docker.tar "${{ steps.name.outputs.canonical }}-${{ steps.arch.outputs.arch }}"
           clamscan /tmp/docker.tar
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v3
       - name: Push it!
         run: docker push "${{ steps.name.outputs.canonical }}-${{ steps.arch.outputs.arch }}"
       - name: Tag and push additional image


### PR DESCRIPTION
https://console.cloud.google.com/iam-admin/workload-identity-pools/pool/github-actions?orgonly=true&project=ironcore-dev-1&supportedpurview=organizationId

That shows the WIF pool, provider, and connected service account. We might find that we need to expand the permissions sections if for some reason calling workflows need additional things, but I tested in TSP and VB and they both worked. 

In the end I was able to do like I hoped and just assert that `attribute.repository_owner="IronCoreLabs"` instead of having to get repo-specific