### PR TITLE
Fix bump version cb

### DIFF
--- a/.github/bump-version.set.sh
+++ b/.github/bump-version.set.sh
@@ -59,13 +59,13 @@ for FILE in ${VERSFILES} ; do
         ;;
 
     package.json)
+        # Get the root package's name.
+        ROOTJSNAME="$(jq -re '.name' < package.json)"
         if [ "${DIR}" = "." ] || ! jq -re ".dependencies[\"${ROOTJSNAME}\"]" < "${FILE}" ; then
             # This is the root package.json, or we're assuming we're in a monorepo because we aren't dependant on the
             # root, so we want .version.
             jq --indent 4 ".version=\"${NEWVERS}\"" "${FILE}" > "${FILE}.new"
         else
-            # Get the root package's name.
-            ROOTJSNAME="$(jq -re '.name' < package.json)"
             # This package depends on the root, so bump its dependency
             jq --indent 4 ".dependencies[\"${ROOTJSNAME}\"]=\"^${NEWVERS}\"" "${FILE}" > "${FILE}.new"
         fi


### PR DESCRIPTION
Tested locally and confirmed that it works with new CB structure. It also doesn't change the old behavior, if it finds that it's a dependency, it'll update that dep number instead