### PR TITLE
Exempt examples from Bump Version scripts

### DIFF
--- a/.github/bump-version.get.sh
+++ b/.github/bump-version.get.sh
@@ -18,7 +18,8 @@ fi
 
 # Find the version files in this directory or its descendants, but don't recurse too deep.
 # This line must be kept in sync with "bump-version.set.sh".
-VERSFILES=$(find . -maxdepth 3 ! -path ./.git/\* | grep -v /node_modules/ | grep -E '.*/(version|Cargo.toml|version.go|package.json|pom.xml|version.sbt|build.gradle.kts)$')
+# We exclude example directories because they shouldn't always depend on the latest version (it's normally unreleased)
+VERSFILES=$(find . -maxdepth 6 ! -path ./.git/\* | grep -v /node_modules/ | grep -v /example*/** | grep -E '.*/(version|Cargo.toml|version.go|package.json|pom.xml|version.sbt|build.gradle.kts)$')
 
 # Do we have at least one?
 if [ -z "${VERSFILES}" ] ; then
@@ -50,7 +51,7 @@ for FILE in ${VERSFILES} ; do
             VERS=$(jq -re '.version' < "${FILE}")
         else
             # This isn't the root package.json, so we assume it depends on the package declared in the root package.json. We need to
-            # Strip off any leading "^".
+            # strip off any leading "^".
             VERS=${VERS/^/}
         fi
         ;;

--- a/.github/bump-version.set.sh
+++ b/.github/bump-version.set.sh
@@ -33,7 +33,7 @@ fi
 
 # Find the version files in this directory or its descendants, but don't recurse too deep.
 # This line must be kept in sync with "bump-version.get.sh".
-VERSFILES=$(find . -maxdepth 3 ! -path ./.git/\* | grep -v /node_modules/ | grep -E '.*/(version|Cargo.toml|version.go|package.json|pom.xml|version.sbt|build.gradle.kts)$')
+VERSFILES=$(find . -maxdepth 6 ! -path ./.git/\* | grep -v /node_modules/ | grep -v **/example*/** | grep -E '.*/(version|Cargo.toml|version.go|package.json|pom.xml|version.sbt|build.gradle.kts)$')
 
 # Edit the version files.
 for FILE in ${VERSFILES} ; do


### PR DESCRIPTION
This will make the Bump Version scripts not include example directories. Also increased the max-depth since we have some deep repos

Example directories will instead have workflows that run weekly to make sure the examples build