### PR TITLE
Add workflow to get TSP ref from a comment

### DIFF
--- a/.github/workflows/get-tsp-ref.yaml
+++ b/.github/workflows/get-tsp-ref.yaml
@@ -4,11 +4,14 @@ on:
   workflow_call:
     outputs:
       tsp_ref:
-        description: "The ref of the TSP to use"
+        description: 'The ref of the TSP to use. Use a comment on the PR like this to change: `CI_branches: {"tenant-security-proxy": "some_branch"}`'
         value: ${{ jobs.get_ref.outputs.tenant-security-proxy }}
 jobs:
-  # Look for a comment telling us what refs to use from the other repos we depend on.
-  # To add additional repositories, add them to "outputs" and to the "Setup list of required repos" step.
+  # If your tests don't build against the default branch of TSP, you can change it by adding a command to the pull request. The
+  # comment should contain the string `CI_branches` and a JSON object like
+  # `{"tenant-security-proxy": "some_branch"}`. You can include formatting, prose, or a haiku,
+  # but no `{` or `}` characters. Example:
+  # CI_branches: {"tenant-security-proxy": "some_branch"}
   get_ref:
     # Only run if it's on a PR.
     if: github.base_ref != ''
@@ -16,9 +19,8 @@ jobs:
     outputs:
       tenant-security-proxy: ${{ steps.get_ref.outputs.tenant-security-proxy }}
     steps:
-      - name: Setup list of required repos
-        run: |
-          echo tenant-security-proxy >> repos
+      - name: Add TSP to repo list
+        run: echo tenant-security-proxy >> repos
       - name: Get PR number
         id: get_pr
         run: |


### PR DESCRIPTION
This is taken from TSC-java and should be usable from there as well. It outputs the TSP ref as `tsp_ref`