### PR TITLE
Fix bug with typescript-release.yaml

### DIFF
--- a/.github/workflows/typescript-release.yaml
+++ b/.github/workflows/typescript-release.yaml
@@ -46,7 +46,7 @@ jobs:
           echo "/usr/local/bin" >> $GITHUB_PATH
       - run: yarn
       - name: Pre-publish steps
-        if: ${{ inputs.pre_publish_steps }} != ""
+        if: inputs.pre_publish_steps != ''
         run: ${{inputs.pre_publish_steps}}
       - run: npm publish ${{ inputs.add_access_public && '--access public' || '' }}
         working-directory: ${{ inputs.publish_working_directory }}


### PR DESCRIPTION
VSCode GitHub Actions extension added a new lint that caught an issue with our existing expression:
```
Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy. Did you mean to put the entire expression inside ${{ }}?(expression-literal-text-in-condition)
```