### PR TITLE
Remove prerelease label after Rust Release

### DIFF
--- a/.github/workflows/rust-release.yaml
+++ b/.github/workflows/rust-release.yaml
@@ -18,6 +18,8 @@ jobs:
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_API_KEY }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - run: cargo package
@@ -27,3 +29,8 @@ jobs:
       - name: Publish!
         if: ${{ !inputs.dry_run }}
         run: cargo publish
+      - name: Mark GitHub release as not prerelease
+        if: ${{ !inputs.dry_run && github.event.release != null }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit --tag "${{ github.event.release.tag_name }}" --prerelease=false "${{ github.event.release.name }}"


### PR DESCRIPTION
After a successful release, updates the release that triggered the workflow to no longer be a pre-release